### PR TITLE
Decode characters from $ref and normalize names used for constants

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ reynard.base_url('http://test.example.com/v1')
 You also have access to all servers in the specification so you can automatically select one however you want.
 
 ```ruby
-base_url = @reynard.servers.map(&:url).find do |url|
+base_url = reynard.servers.map(&:url).find do |url|
   /staging/.match(url)
 end
 reynard.base_url(base_url)

--- a/test/files/openapi/weird.yml
+++ b/test/files/openapi/weird.yml
@@ -1,0 +1,43 @@
+openapi: "3.0.0"
+info:
+  title: Complex or specific issues all in one API.
+  version: 1.0.0
+  contact: {}
+  description: Very unfortunate.
+servers:
+  - url: https://example.com:9644/+%2F+%F0%9F%A7%98/v0
+tags:
+  - name: complex
+    description: Lot of examples.
+paths:
+  /%F0%9F%8D%8E/{placeholder}/next:
+    get:
+      summary: Get next apple
+      description: Get the next apple for the specified placeholder.
+      operationId: getApple
+      tags:
+        - complex
+      parameters:
+        - name: placeholder
+          in: path
+          description: A placeholder for your favorite text.
+          required: true
+          schema:
+            type: string
+      responses:
+        '200':
+          description: A clown.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/%20howdy%E2%9A%A0%EF%B8%8F.Pardner"
+components:
+  schemas:
+    " howdy⚠️.Pardner":
+      type: object
+      required:
+        - placeholder
+      properties:
+        placeholder:
+          type: string
+

--- a/test/reynard_test.rb
+++ b/test/reynard_test.rb
@@ -62,6 +62,22 @@ class ReynardTest < Reynard::Test
     end
   end
 
+  test 'performs a request when a $ref to a schema has character encoding' do
+    apple = { placeholder: '✅' }
+    reynard = Reynard.new(filename: fixture_file('openapi/weird.yml'))
+    context = reynard
+              .operation('getApple')
+              .params(placeholder: '⸮')
+    stub_request(:get, "#{reynard.servers.first.url}#{context.full_path}")
+      .to_return(
+        body: MultiJson.dump(apple),
+        headers: {
+          'Content-Type' => 'application/json; charset=utf-8'
+        }
+      )
+    assert_equal apple[:placeholder], context.execute.placeholder
+  end
+
   class Mock
     def request(_uri, _request)
       response = Net::HTTPResponse::CODE_TO_OBJ['404'].new('HTTP/1.1', '400', 'Not Found')


### PR DESCRIPTION
Also fixes an example in the README.

Closes #4
Closes #5