### PR TITLE
Return Reponse object from #execute

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ reynard.base_url(base_url)
 Assuming there is an operation called `employeeByUuid` you can it as shown below.
 
 ```ruby
-employee = reynard.
+response = reynard.
   operation('employeeByUuid').
   params(uuid: uuid).
   execute
@@ -60,10 +60,25 @@ employee = reynard.
 When an operation requires a body, you can add it as structured data.
 
 ```ruby
-employee = reynard.
+response = reynard.
   operation('createEmployee').
   body(name: 'Sam Seven').
   execute
+```
+
+In case the response matches a response in the specification it will attempt to build an object using the specified schema.
+
+```ruby
+response.object.name #=> 'Sam Seven'
+```
+
+The response object shared much of its interface with `Net::HTTP::Response`.
+
+```ruby
+response.code #=> '200'
+response.content_type #=> 'application/json'
+response['Content-Type'] #=> 'application/json'
+response.body #=> '{"name":"Sam Seven"}'
 ```
 
 ## Mocking

--- a/lib/reynard/context.rb
+++ b/lib/reynard/context.rb
@@ -43,7 +43,7 @@ class Reynard
     end
 
     def execute
-      build_object(build_request.perform)
+      build_response(build_request.perform)
     end
 
     private
@@ -63,32 +63,12 @@ class Reynard
       Reynard::Http::Request.new(request_context: @request_context)
     end
 
-    def build_object(http_response)
-      media_type = @specification.media_type(
-        @request_context.operation.node,
-        http_response.code,
-        http_response.content_type
-      )
-      if media_type
-        build_object_with_media_type(http_response, media_type)
-      else
-        build_object_without_media_type(http_response)
-      end
-    end
-
-    def build_object_with_media_type(http_response, media_type)
-      ObjectBuilder.new(
-        media_type: media_type,
-        schema: @specification.schema(media_type.node),
+    def build_response(http_response)
+      Reynard::Http::Response.new(
+        specification: @specification,
+        request_context: @request_context,
         http_response: http_response
-      ).call
-    end
-
-    def build_object_without_media_type(http_response)
-      # Try to parse the response as JSON and give up otherwise.
-      OpenStruct.new(MultiJson.load(http_response.body))
-    rescue StandardError
-      http_response.body
+      )
     end
   end
 end

--- a/lib/reynard/http.rb
+++ b/lib/reynard/http.rb
@@ -3,5 +3,6 @@
 class Reynard
   class Http
     autoload :Request, 'reynard/http/request'
+    autoload :Response, 'reynard/http/response'
   end
 end

--- a/lib/reynard/http/response.rb
+++ b/lib/reynard/http/response.rb
@@ -1,0 +1,55 @@
+# frozen_string_literal: true
+
+class Reynard
+  class Http
+    # Wraps an HTTP response and returns an object when it can find a definition for the response
+    # in the specification.
+    class Response
+      extend Forwardable
+      def_delegators :@http_response, :code, :content_type, :[], :body
+
+      def initialize(specification:, request_context:, http_response:)
+        @specification = specification
+        @request_context = request_context
+        @http_response = http_response
+      end
+
+      # Instantiates an object based on the schema that fits the response.
+      def object
+        return @object if defined?(@object)
+
+        @object = build_object
+      end
+
+      private
+
+      def build_object
+        media_type = @specification.media_type(
+          @request_context.operation.node,
+          @http_response.code,
+          @http_response.content_type
+        )
+        if media_type
+          build_object_with_media_type(media_type)
+        else
+          build_object_without_media_type
+        end
+      end
+
+      def build_object_with_media_type(media_type)
+        ObjectBuilder.new(
+          media_type: media_type,
+          schema: @specification.schema(media_type.node),
+          http_response: @http_response
+        ).call
+      end
+
+      def build_object_without_media_type
+        # Try to parse the response as JSON and give up otherwise.
+        OpenStruct.new(MultiJson.load(@http_response.body))
+      rescue StandardError
+        @http_response.body
+      end
+    end
+  end
+end

--- a/test/integration/reynard_test.rb
+++ b/test/integration/reynard_test.rb
@@ -20,14 +20,18 @@ module Integration
 
     test 'fetches a collection' do
       with_simple_service do
-        books = @reynard.operation('listBooks').execute
+        response = @reynard.operation('listBooks').execute
+        assert_equal '200', response.code
+        books = response.object
         assert_kind_of Reynard::Models::Books, books
       end
     end
 
     test 'fetches an object' do
       with_simple_service do
-        book = @reynard.operation('fetchBook').params(id: 1).execute
+        response = @reynard.operation('fetchBook').params(id: 1).execute
+        assert_equal '200', response.code
+        book = response.object
         assert_kind_of Reynard::Models::Book, book
       end
     end
@@ -35,7 +39,9 @@ module Integration
     test 'creates an object' do
       with_simple_service do
         name = 'An unexpected occurance'
-        book = @reynard.operation('createBook').body({ 'name' => name }).execute
+        response = @reynard.operation('createBook').body({ 'name' => name }).execute
+        assert_equal '200', response.code
+        book = response.object
         assert_kind_of Reynard::Models::Book, book
         assert_equal name, book.name
       end
@@ -43,7 +49,9 @@ module Integration
 
     test 'returns an error when fetching an object fails' do
       with_simple_service do
-        error = @reynard.operation('fetchBook').params(id: -1).execute
+        response = @reynard.operation('fetchBook').params(id: -1).execute
+        assert_equal '404', response.code
+        error = response.object
         assert_kind_of Reynard::Models::Error, error
         assert_equal 'not_found', error.error
       end
@@ -54,7 +62,8 @@ module Integration
         threads = []
         3.times do
           threads << Thread.new do
-            assert_equal 1, @reynard.operation('fetchBook').params(id: 1).execute.id
+            response = @reynard.operation('fetchBook').params(id: 1).execute
+            assert_equal 1, response.object.id
           end
         end
         threads.map(&:join)

--- a/test/reynard/context_test.rb
+++ b/test/reynard/context_test.rb
@@ -73,71 +73,82 @@ class Reynard
       stub_request(:get, 'http://example.com/v1/books').and_return(
         body: '[{"id":1},{"id":2},{"id":3}]'
       )
-      result = @context.operation('listBooks').execute
-      assert_equal [1, 2, 3], result.map(&:id)
+      response = @context.operation('listBooks').execute
+      assert_equal '200', response.code
+      assert_equal [1, 2, 3], response.object.map(&:id)
     end
 
     test 'executes a request for a single resource' do
       stub_request(:get, 'http://example.com/v1/books/1').and_return(body: '{"id":1}')
-      result = @context.operation('fetchBook').params(id: 1).execute
-      assert_equal 1, result.id
+      response = @context.operation('fetchBook').params(id: 1).execute
+      assert_equal '200', response.code
+      assert_equal 1, response.object.id
     end
 
     test 'executes a request for a single resource with a specific content-type' do
       stub_request(:get, 'http://example.com/v1/books/1').and_return(body: '{"id":1}')
-      result = @context
-               .operation('fetchBook')
-               .headers('Accept' => 'application/json')
-               .params(id: 1)
-               .execute
-      assert_equal 1, result.id
+      response = @context
+                 .operation('fetchBook')
+                 .headers('Accept' => 'application/json')
+                 .params(id: 1)
+                 .execute
+      assert_equal '200', response.code
+      assert_equal 1, response.object.id
     end
 
     test 'executes a POST request with a body' do
       stub_request(:post, 'http://example.com/v1/books').and_return(body: '{"id":1,"name":"Howdy"}')
-      result = @context.operation('createBook').body(name: 'Howdy').execute
-      assert_equal 1, result.id
-      assert_equal 'Howdy', result.name
+      response = @context.operation('createBook').body(name: 'Howdy').execute
+      assert_equal '200', response.code
+      assert_equal 1, response.object.id
+      assert_equal 'Howdy', response.object.name
     end
 
     test 'executes a POST request without a body' do
       stub_request(:post, 'http://example.com/v1/books').and_return(body: '{"id":1,"name":"Howdy"}')
-      result = @context.operation('createBook').execute
-      assert_equal 1, result.id
-      assert_equal 'Howdy', result.name
+      response = @context.operation('createBook').execute
+      assert_equal '200', response.code
+      assert_equal 1, response.object.id
+      assert_equal 'Howdy', response.object.name
     end
 
     test 'executes a PUT request with a body' do
       stub_request(:put, 'http://example.com/v1/books/56').and_return(body: '{"id":1,"name":"Howdy"}')
-      result = @context.operation('updateBook').params(id: 56).body(name: 'Howdy').execute
-      assert_equal 1, result.id
-      assert_equal 'Howdy', result.name
+      response = @context.operation('updateBook').params(id: 56).body(name: 'Howdy').execute
+      assert_equal '200', response.code
+      assert_equal 1, response.object.id
+      assert_equal 'Howdy', response.object.name
     end
 
     test 'executes a PUT request without a body' do
       stub_request(:put, 'http://example.com/v1/books/83').and_return(body: '{"id":1,"name":"Howdy"}')
-      result = @context.operation('updateBook').params(id: 83).execute
-      assert_equal 1, result.id
-      assert_equal 'Howdy', result.name
+      response = @context.operation('updateBook').params(id: 83).execute
+      assert_equal '200', response.code
+      assert_equal 1, response.object.id
+      assert_equal 'Howdy', response.object.name
     end
 
     test 'executes a PATCH request with a body' do
       stub_request(:patch, 'http://example.com/v1/books/12').and_return(body: '{"id":1,"name":"Howdy"}')
-      result = @context.operation('updateBook2').params(id: 12).body(name: 'Howdy').execute
-      assert_equal 1, result.id
-      assert_equal 'Howdy', result.name
+      response = @context.operation('updateBook2').params(id: 12).body(name: 'Howdy').execute
+      assert_equal '200', response.code
+      assert_equal 1, response.object.id
+      assert_equal 'Howdy', response.object.name
     end
 
     test 'executes a PATCH request without a body' do
       stub_request(:patch, 'http://example.com/v1/books/93').and_return(body: '{"id":1,"name":"Howdy"}')
-      result = @context.operation('updateBook2').params(id: 93).execute
-      assert_equal 1, result.id
-      assert_equal 'Howdy', result.name
+      response = @context.operation('updateBook2').params(id: 93).execute
+      assert_equal '200', response.code
+      assert_equal 1, response.object.id
+      assert_equal 'Howdy', response.object.name
     end
 
     test 'executes a DELETE request with a body' do
       stub_request(:delete, 'http://example.com/v1/books/29').and_return(status: 204)
-      assert_nil @context.operation('deleteBook').params(id: 29).execute
+      response = @context.operation('deleteBook').params(id: 29).execute
+      assert_equal '204', response.code
+      assert_nil response.object
     end
   end
 
@@ -152,9 +163,9 @@ class Reynard
       stub_request(:get, 'http://example.com/clowns').and_return(
         status: 500, body: '{"message":"Howdy"}'
       )
-      result = @context.operation('listClowns').execute
-      assert_kind_of OpenStruct, result
-      assert_equal 'Howdy', result.message
+      response = @context.operation('listClowns').execute
+      assert_kind_of OpenStruct, response.object
+      assert_equal 'Howdy', response.object.message
     end
   end
 end

--- a/test/reynard/http/response_test.rb
+++ b/test/reynard/http/response_test.rb
@@ -1,0 +1,45 @@
+# frozen_string_literal: true
+
+require_relative '../../test_helper'
+
+class Reynard
+  class Http
+    # Response is mostly tested through Context because replicating a RequestContext without a full
+    # specification is kind of cumbersome.
+    class ResponseTest < Reynard::Test
+      def setup
+        @specification = Specification.new(filename: fixture_file('openapi/simple.yml'))
+        @request_context = RequestContext.new(
+          base_url: @specification.default_base_url,
+          headers: {},
+          operation: @specification.operation('sampleBook')
+        )
+        @body = '{"id":12}'
+
+        response_class = Net::HTTPResponse::CODE_TO_OBJ['200']
+        @http_response = response_class.new('HTTP/1.1', '200', 'OK')
+        @http_response['Content-Type'] = 'application/json'
+        @http_response['X-Sample'] = '👋'
+        @http_response.instance_variable_set('@read', true)
+        @http_response.instance_variable_set('@body', @body)
+
+        @response = Response.new(
+          specification: @specification,
+          request_context: @request_context,
+          http_response: @http_response
+        )
+      end
+
+      test 'forwards methods to the HTTP response' do
+        assert_equal '200', @response.code
+        assert_equal 'application/json', @response.content_type
+        assert_equal '👋', @response['X-Sample']
+        assert_equal @body, @response.body
+      end
+
+      test 'builds a response object' do
+        assert_equal 12, @response.object.id
+      end
+    end
+  end
+end

--- a/test/reynard_test.rb
+++ b/test/reynard_test.rb
@@ -56,9 +56,12 @@ class ReynardTest < Reynard::Test
           'Content-Type' => 'application/json; charset=utf-8'
         }
       )
-    record = context.execute
+    response = context.execute
+    assert_equal '200', response.code
+    assert_equal 'application/json', response.content_type
+    object = response.object
     @book.each do |name, value|
-      assert_equal value, record.send(name)
+      assert_equal value, object.send(name)
     end
   end
 
@@ -75,7 +78,10 @@ class ReynardTest < Reynard::Test
           'Content-Type' => 'application/json; charset=utf-8'
         }
       )
-    assert_equal apple[:placeholder], context.execute.placeholder
+    response = context.execute
+    assert_equal '200', response.code
+    object = response.object
+    assert_equal apple[:placeholder], object.placeholder
   end
 
   class Mock
@@ -94,7 +100,7 @@ class ReynardTest < Reynard::Test
               .new(filename: fixture_file('openapi/simple.yml'))
               .operation('fetchBook')
               .params(id: 42)
-    assert_equal 'Not Found', context.execute.message
+    assert_equal 'Not Found', context.execute.object.message
   ensure
     Reynard.http = before
   end


### PR DESCRIPTION
Instead of the the interpreted object.

Closes #9.
