### PR TITLE
Support external references in specifications

### DIFF
--- a/lib/reynard.rb
+++ b/lib/reynard.rb
@@ -15,6 +15,7 @@ class Reynard
   def_delegators :@specification, :servers
 
   autoload :Context, 'reynard/context'
+  autoload :External, 'reynard/external'
   autoload :GroupedParameters, 'reynard/grouped_parameters'
   autoload :Http, 'reynard/http'
   autoload :Logger, 'reynard/logger'

--- a/lib/reynard/external.rb
+++ b/lib/reynard/external.rb
@@ -1,0 +1,34 @@
+# frozen_string_literal: true
+
+require 'rack'
+
+class Reynard
+  # Loads external references.
+  class External
+    def initialize(path:, ref:)
+      @path = path
+      @relative_path, @anchor = ref.split('#', 2)
+    end
+
+    def path
+      return [] unless @anchor
+
+      @anchor.split('/')[1..]
+    end
+
+    def data
+      File.open(filename, encoding: 'UTF-8') do |file|
+        YAML.safe_load(file, aliases: true)
+      end
+    end
+
+    private
+
+    def filename
+      filename = File.expand_path(@relative_path, @path)
+      return filename if filename.start_with?(@path)
+
+      raise 'You are only allowed to reference files relative to the specification file.'
+    end
+  end
+end

--- a/lib/reynard/object_builder.rb
+++ b/lib/reynard/object_builder.rb
@@ -46,7 +46,7 @@ class Reynard
     end
 
     def self.model_class_get(name)
-      Reynard::Models.const_get(name)
+      Kernel.const_get("::Reynard::Models::#{name}")
     rescue NameError
       nil
     end

--- a/lib/reynard/specification.rb
+++ b/lib/reynard/specification.rb
@@ -102,11 +102,14 @@ class Reynard
 
     def self.normalize_model_name(name)
       # 1. Unescape encoded characters to create an UTF-8 string
-      # 2. Replace all non-alphabetic characters with a space (not allowed in Ruby constant)
-      # 3. Camelcase
+      # 2. Remove extensions for regularly used external schema files
+      # 3. Replace all non-alphabetic characters with a space (not allowed in Ruby constant)
+      # 4. Camelcase
       Rack::Utils.unescape_path(name)
+                 .gsub(/(.yml|.yaml|.json)\Z/, '')
                  .gsub(/[^[:alpha:]]/, ' ')
                  .gsub(/(\s+)([[:alpha:]])/) { Regexp.last_match(2).upcase }
+                 .gsub(/\A(.)/) { Regexp.last_match(1).upcase }
     end
 
     private

--- a/test/files/openapi/external.yml
+++ b/test/files/openapi/external.yml
@@ -32,3 +32,9 @@ paths:
             application/json:
               schema:
                 $ref: './schemas/author.yml'
+        default:
+          description: An error.
+          content:
+            application/json:
+              schema:
+                $ref: "./simple.yml#/components/schemas/Error"

--- a/test/files/openapi/external.yml
+++ b/test/files/openapi/external.yml
@@ -1,0 +1,34 @@
+openapi: "3.0.0"
+info:
+  title: Library
+  version: 1.0.0
+  contact: {}
+  description: It authors!
+servers:
+  - url: http://example.com/v1
+  - url: http://staging.example.com/v1
+tags:
+  - name: authors
+    description: Author operations
+paths:
+  /authors/{id}:
+    get:
+      summary: Fetch author
+      description: Fetch all details for a author.
+      operationId: fetchAuthor
+      tags:
+        - authors
+      parameters:
+        - name: id
+          in: path
+          description: The numeric ID of the author.
+          required: true
+          schema:
+            type: integer
+      responses:
+        '200':
+          description: A author.
+          content:
+            application/json:
+              schema:
+                $ref: './schemas/author.yml'

--- a/test/files/openapi/schemas/author.yml
+++ b/test/files/openapi/schemas/author.yml
@@ -1,0 +1,11 @@
+type: object
+title: Author
+description: >-
+  An author of a book.
+required: [id, name]
+properties:
+  id:
+    type: integer
+  name:
+    type: string
+additionalProperties: false

--- a/test/reynard/external_test.rb
+++ b/test/reynard/external_test.rb
@@ -1,0 +1,31 @@
+# frozen_string_literal: true
+
+require_relative '../test_helper'
+
+class Reynard
+  class ExternalTest < Reynard::Test
+    test 'raises an exception when attempting to access a file not relative to specification' do
+      assert_raises(RuntimeError) do
+        External.new(path: FILES_ROOT, ref: '../../../passwords.txt').data
+      end
+    end
+
+    test 'loads data from a schema relative to a specification' do
+      path = File.join(FILES_ROOT, 'openapi')
+      data = External.new(path: path, ref: './schemas/author.yml').data
+      assert_equal 'Author', data['title']
+    end
+
+    test 'returns an empty path when there is no anchor in the ref' do
+      path = File.join(FILES_ROOT, 'openapi')
+      external = External.new(path: path, ref: './schemas/author.yml')
+      assert_equal [], external.path
+    end
+
+    test 'returns a path when there is an anchor in the ref' do
+      path = File.join(FILES_ROOT, 'openapi')
+      external = External.new(path: path, ref: './schemas/author.yml#/properties/id')
+      assert_equal %w[properties id], external.path
+    end
+  end
+end

--- a/test/reynard/object_builder_test.rb
+++ b/test/reynard/object_builder_test.rb
@@ -41,4 +41,26 @@ class Reynard
       assert_equal 'Black Science', record.name
     end
   end
+
+  class ExternalObjectBuilderTest < Reynard::Test
+    Response = Struct.new(:body, keyword_init: true)
+
+    def setup
+      @specification = Specification.new(filename: fixture_file('openapi/external.yml'))
+    end
+
+    test 'builds a singular record' do
+      operation = @specification.operation('fetchAuthor')
+      media_type = @specification.media_type(operation.node, '200', 'application/json')
+      schema = @specification.schema(media_type.node)
+      record = Reynard::ObjectBuilder.new(
+        media_type: media_type,
+        schema: schema,
+        http_response: Response.new(body: '{"id":42,"name":"Jerry Writer"}')
+      ).call
+      assert_kind_of(Reynard::ObjectBuilder.model_class('Author', 'object'), record)
+      assert_equal 42, record.id
+      assert_equal 'Jerry Writer', record.name
+    end
+  end
 end

--- a/test/reynard/specification_test.rb
+++ b/test/reynard/specification_test.rb
@@ -8,6 +8,19 @@ class Reynard
       @specification = Specification.new(filename: fixture_file('openapi/simple.yml'))
     end
 
+    test 'normalizes models names' do
+      examples = {
+        'Author' => 'Author',
+        'author.yml' => 'Author',
+        'general_error.json' => 'GeneralError',
+        'GeneralError' => 'GeneralError',
+        '%20howdy%E2%9A%A0%EF%B8%8F.Pardner' => 'HowdyPardner'
+      }
+      assert_equal(
+        examples.values, examples.keys.map { |example| Specification.normalize_model_name(example) }
+      )
+    end
+
     test 'initializes with an OpenAPI filename' do
       assert_equal 'Library', @specification.dig('info', 'title')
     end

--- a/test/reynard/specification_test.rb
+++ b/test/reynard/specification_test.rb
@@ -226,4 +226,43 @@ class Reynard
       assert_nil @specification.media_type(operation.node, '500', nil)
     end
   end
+
+  class ExernalSpecificationTest < Reynard::Test
+    def setup
+      @specification = Specification.new(filename: fixture_file('openapi/external.yml'))
+    end
+
+    test 'digs into an external file' do
+      data = @specification.dig(
+        'paths', '/authors/{id}', 'get', 'responses', '200',
+        'content', 'application/json', 'schema'
+      )
+      assert_equal 'Author', data['title']
+    end
+
+    test 'digs into an external file through a reference' do
+      data = @specification.dig(
+        'paths', '/authors/{id}', 'get', 'responses', '200',
+        'content', 'application/json', 'schema',
+        'properties', 'id', 'type'
+      )
+      assert_equal 'integer', data
+    end
+
+    test 'digs into an external file with an anchor' do
+      data = @specification.dig(
+        'paths', '/authors/{id}', 'get', 'responses', 'default',
+        'content', 'application/json', 'schema'
+      )
+      assert_equal %w[code message], data['required']
+    end
+
+    test 'digs into an external file through a refenence with with an anchor' do
+      data = @specification.dig(
+        'paths', '/authors/{id}', 'get', 'responses', 'default',
+        'content', 'application/json', 'schema', 'required'
+      )
+      assert_equal %w[code message], data
+    end
+  end
 end


### PR DESCRIPTION
Support references like:

```
$ref: './schemas/author.yml'
$ref: "./simple.yml#/components/schemas/Error"
```

* Fixes an issue with looking up model classes.
* Generates nicer class names for models when references as external.

Closes #19.