### PR TITLE
Use Array as the unnamed class for collections and use the schema's title

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 /Gemfile.lock
+/.spectral.yml

--- a/bin/reynard
+++ b/bin/reynard
@@ -1,0 +1,22 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+
+if ARGV[0] == 'lint'
+  Dir.glob('**/*.{yml,yaml}') do |path|
+    File.open(path, 'r') do |file|
+      leading = file.read(64)
+      match = /^openapi:\s+"?([\d.]+)"?$/.match(leading)
+      next unless match
+
+      version = match[1]
+      puts "#{path} (#{version}):"
+      system("spectral lint #{path}")
+      puts
+      puts
+    end
+  end
+else
+  puts "Usage: #{$PROGRAM_NAME} lint"
+  puts '  Finds all YAML files with OpenAPI specs relative to the current path and'
+  puts ' lints them using spectral.'
+end

--- a/lib/reynard/object_builder.rb
+++ b/lib/reynard/object_builder.rb
@@ -14,6 +14,8 @@ class Reynard
     def object_class
       if @media_type.schema_name
         self.class.model_class(@media_type.schema_name, @schema.object_type)
+      elsif @schema.object_type == 'array'
+        Array
       else
         Reynard::Model
       end

--- a/test/files/openapi/titled.yml
+++ b/test/files/openapi/titled.yml
@@ -1,0 +1,42 @@
+openapi: "3.0.3"
+info:
+  title: Library
+  version: 1.0.0
+  contact: {}
+  description: ISBN
+servers:
+  - url: http://example.com/v1
+tags:
+  - name: isbn
+    description: ISBN related operations
+paths:
+  /isbn:
+    get:
+      summary: Search for ISBNs
+      description: Returns a list of all books matching a title.
+      operationId: listISBN
+      tags:
+        - isbn
+      parameters:
+        - name: query
+          in: query
+          description: A query on the name of a book.
+          required: true
+          schema:
+            type: string
+      responses:
+        "200":
+          description: A list of ISBNs.
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  type: object
+                  title: ISBN
+                  description: Combination of an ISBN with the book's title for presentation.
+                  properties:
+                    isbn:
+                      type: string
+                    title:
+                      type: string

--- a/test/files/openapi/weird.yml
+++ b/test/files/openapi/weird.yml
@@ -31,6 +31,24 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/%20howdy%E2%9A%A0%EF%B8%8F.Pardner"
+  /%2F:
+    patch:
+      summary: Root
+      description: Get root path
+      operationId: updateRoot
+      tags:
+        - complex
+      responses:
+        '200':
+          description: " it's not empty 🚕"
+          content:
+            application/json:
+              schema:
+                type: object
+                title: " A %2F root with 🚕 in the "
+                properties:
+                  name:
+                    type: string
 components:
   schemas:
     " howdy⚠️.Pardner":

--- a/test/reynard/object_builder_test.rb
+++ b/test/reynard/object_builder_test.rb
@@ -17,14 +17,23 @@ class Reynard
       collection = Reynard::ObjectBuilder.new(
         media_type: media_type,
         schema: schema,
-        http_response: Response.new(body: '[{"id":42,"name":"Black Science"}]')
+        http_response: Response.new(
+          body: '[{"id":42,"name":"Black Science"},{"id":51,"name":"Dead Astronauts"}]'
+        )
       ).call
       assert_kind_of(Reynard::ObjectBuilder.model_class('Books', 'array'), collection)
 
-      record = collection.first
+      assert_equal 2, collection.length
+
+      record = collection[0]
       assert_kind_of(Reynard::ObjectBuilder.model_class('Book', 'array'), record)
       assert_equal 42, record.id
       assert_equal 'Black Science', record.name
+
+      record = collection[1]
+      assert_kind_of(Reynard::ObjectBuilder.model_class('Book', 'array'), record)
+      assert_equal 51, record.id
+      assert_equal 'Dead Astronauts', record.name
     end
 
     test 'builds a singular record' do
@@ -61,6 +70,57 @@ class Reynard
       assert_kind_of(Reynard::ObjectBuilder.model_class('Author', 'object'), record)
       assert_equal 42, record.id
       assert_equal 'Jerry Writer', record.name
+    end
+  end
+
+  class TitledObjectBuilderTest < Reynard::Test
+    Response = Struct.new(:body, keyword_init: true)
+
+    def setup
+      @specification = Specification.new(filename: fixture_file('openapi/titled.yml'))
+    end
+
+    test 'builds a collection' do
+      operation = @specification.operation('listISBN')
+      media_type = @specification.media_type(operation.node, '200', 'application/json')
+      schema = @specification.schema(media_type.node)
+      collection = Reynard::ObjectBuilder.new(
+        media_type: media_type,
+        schema: schema,
+        http_response: Response.new(
+          body: '[{"isbn":"9781534307407","title":"Black Science Premiere Hardcover Volume 1 Remastered Edition (Black Science Omnibus, 1)"}]'
+        )
+      ).call
+      assert_kind_of(Array, collection)
+
+      record = collection[0]
+      assert_kind_of(Reynard::ObjectBuilder.model_class('ISBN', 'object'), record)
+      assert_equal '9781534307407', record.isbn
+      assert_equal(
+        'Black Science Premiere Hardcover Volume 1 Remastered Edition (Black Science Omnibus, 1)',
+        record.title
+      )
+    end
+  end
+
+  class WeirdObjectBuilderTest < Reynard::Test
+    Response = Struct.new(:body, keyword_init: true)
+
+    def setup
+      @specification = Specification.new(filename: fixture_file('openapi/weird.yml'))
+    end
+
+    test 'builds a singular record' do
+      operation = @specification.operation('updateRoot')
+      media_type = @specification.media_type(operation.node, '200', 'application/json')
+      schema = @specification.schema(media_type.node)
+      record = Reynard::ObjectBuilder.new(
+        media_type: media_type,
+        schema: schema,
+        http_response: Response.new(body: '{"name":"😇"}')
+      ).call
+      assert_kind_of(Reynard::ObjectBuilder.model_class('AFRootWithInThe', 'object'), record)
+      assert_equal '😇', record.name
     end
   end
 end


### PR DESCRIPTION
Use the schema's title to create a model name when there is no $ref. Use Array as the default class for collections when we can't find a model class for a collection.

Closes #21