### PR TITLE
Add accessors to Response for status code groups.

### DIFF
--- a/lib/reynard/http/response.rb
+++ b/lib/reynard/http/response.rb
@@ -14,6 +14,31 @@ class Reynard
         @http_response = http_response
       end
 
+      # True when the response code is in the 1xx range.
+      def informational?
+        code.start_with?('1')
+      end
+
+      # True when the response code is in the 2xx range.
+      def success?
+        code.start_with?('2')
+      end
+
+      # True when the response code is in the 3xx range.
+      def redirection?
+        code.start_with?('3')
+      end
+
+      # True when the response code is in the 4xx range.
+      def client_error?
+        code.start_with?('4')
+      end
+
+      # True when the response code is in the 5xx range.
+      def server_error?
+        code.start_with?('5')
+      end
+
       # Instantiates an object based on the schema that fits the response.
       def object
         return @object if defined?(@object)

--- a/test/reynard/http/response_test.rb
+++ b/test/reynard/http/response_test.rb
@@ -15,9 +15,11 @@ class Reynard
           operation: @specification.operation('sampleBook')
         )
         @body = '{"id":12}'
+      end
 
-        response_class = Net::HTTPResponse::CODE_TO_OBJ['200']
-        @http_response = response_class.new('HTTP/1.1', '200', 'OK')
+      def response(code, message)
+        response_class = Net::HTTPResponse::CODE_TO_OBJ[code]
+        @http_response = response_class.new('HTTP/1.1', code, message)
         @http_response['Content-Type'] = 'application/json'
         @http_response['X-Sample'] = '👋'
         @http_response.instance_variable_set('@read', true)
@@ -31,14 +33,61 @@ class Reynard
       end
 
       test 'forwards methods to the HTTP response' do
-        assert_equal '200', @response.code
-        assert_equal 'application/json', @response.content_type
-        assert_equal '👋', @response['X-Sample']
-        assert_equal @body, @response.body
+        response = response('200', 'OK')
+        assert_equal '200', response.code
+        assert_equal 'application/json', response.content_type
+        assert_equal '👋', response['X-Sample']
+        assert_equal @body, response.body
       end
 
       test 'builds a response object' do
-        assert_equal 12, @response.object.id
+        response = response('200', 'OK')
+        assert_equal 12, response.object.id
+      end
+
+      test 'response code in the 1xx range indicates an informational response' do
+        response = response('100', 'Continue')
+        assert response.informational?
+        refute response.success?
+        refute response.redirection?
+        refute response.client_error?
+        refute response.server_error?
+      end
+
+      test 'response code in the 2xx range indicates a successful response' do
+        response = response('204', 'No Content')
+        refute response.informational?
+        assert response.success?
+        refute response.redirection?
+        refute response.client_error?
+        refute response.server_error?
+      end
+
+      test 'response code in the 3xx range indicates a redirection' do
+        response = response('308', 'Permanent Redirect')
+        refute response.informational?
+        refute response.success?
+        assert response.redirection?
+        refute response.client_error?
+        refute response.server_error?
+      end
+
+      test 'response code in the 4xx range indicates a client error' do
+        response = response('404', 'Not Found')
+        refute response.informational?
+        refute response.success?
+        refute response.redirection?
+        assert response.client_error?
+        refute response.server_error?
+      end
+
+      test 'response code in the 5xx range indicates a server error' do
+        response = response('500', 'Internal Server Error')
+        refute response.informational?
+        refute response.success?
+        refute response.redirection?
+        refute response.client_error?
+        assert response.server_error?
       end
     end
   end


### PR DESCRIPTION
Logic dealing with responses is not always concerned with the exact response code, but more along the lines of did I do something wrong, or did they do something wrong.

These accessors allow us to write code that reads a bit better in those cases:

```ruby
if response.client_error?
  fix_and_retry
elsif response.server_error?
  report_error
end
```

Closes #23.