### PR TITLE
Change the default User-Agent from Ruby to Reynard/version

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,5 +1,6 @@
 AllCops:
   NewCops: enable
+  SuggestExtensions: false
   TargetRubyVersion: 3.1
 Layout/LineLength:
   Enabled: 100

--- a/Gemfile
+++ b/Gemfile
@@ -5,4 +5,16 @@ source 'https://rubygems.org'
 # Rubocop is used on CI to enforce the Ruby style guide.
 gem 'rubocop'
 
+# Allows us to write unit tests.
+gem 'minitest'
+
+# Used to define a few tasks for testing.
+gem 'rake'
+
+# Mocks HTTP request responses in the test suite.
+gem 'webmock'
+
+# Used as a web server for integration testing actual HTTP requests.
+gem 'webrick'
+
 gemspec

--- a/lib/reynard.rb
+++ b/lib/reynard.rb
@@ -42,6 +42,12 @@ class Reynard
     attr_writer :http
   end
 
+  # Returns a value that will be used by default for Reynard's User-Agent headers. Please use
+  # the +headers+ setter on the context if you want to change this.
+  def self.user_agent
+    "Reynard/#{Reynard::VERSION}"
+  end
+
   # Returns Reynard's global request interface. This is a global object to allow persistent
   # connections, caching, and other features that need a persistent object in the process.
   def self.http

--- a/lib/reynard/http.rb
+++ b/lib/reynard/http.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 class Reynard
+  # Contains classes that wrap Net::HTTP to provide a slightly more convenient interface.
   class Http
     autoload :Request, 'reynard/http/request'
     autoload :Response, 'reynard/http/response'

--- a/lib/reynard/http/request.rb
+++ b/lib/reynard/http/request.rb
@@ -25,8 +25,12 @@ class Reynard
         Net::HTTP.const_get(@request_context.verb.capitalize)
       end
 
+      def request_headers
+        { 'User-Agent' => Reynard.user_agent }.merge(@request_context.headers || {})
+      end
+
       def build_request
-        request = request_class.new(uri, @request_context.headers)
+        request = request_class.new(uri, request_headers)
         if @request_context.body
           @request_context.logger&.debug { @request_context.body }
           request.body = @request_context.body

--- a/reynard.gemspec
+++ b/reynard.gemspec
@@ -32,11 +32,5 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'multi_json'
   spec.add_dependency 'net-http-persistent'
   spec.add_dependency 'rack'
-  spec.add_development_dependency 'minitest'
-  spec.add_development_dependency 'rake'
-  spec.add_development_dependency 'webmock'
-  spec.add_development_dependency 'webrick'
-  spec.metadata = {
-    'rubygems_mfa_required' => 'true'
-  }
+  spec.metadata = { 'rubygems_mfa_required' => 'true' }
 end

--- a/test/reynard/context_test.rb
+++ b/test/reynard/context_test.rb
@@ -173,6 +173,29 @@ class Reynard
       assert_equal 1, lines.length
       assert lines[0].end_with?('INFO -- : POST http://example.com/v1/books')
     end
+
+    test 'includes the User-Agent with a request' do
+      stub_request(:get, 'http://example.com/v1/books').with(
+        headers: { 'User-Agent' => Reynard.user_agent.to_s }
+      ).and_return(
+        body: '[{"id":1},{"id":2},{"id":3}]'
+      )
+      response = @context.operation('listBooks').execute
+      assert_equal '200', response.code
+      assert_equal [1, 2, 3], response.object.map(&:id)
+    end
+
+    test 'allows customization of the User-Agent' do
+      user_agent = 'Weeeeeeeeeeeeee/1.1'
+      stub_request(:get, 'http://example.com/v1/books').with(
+        headers: { 'User-Agent' => user_agent }
+      ).and_return(
+        body: '[{"id":1},{"id":2},{"id":3}]'
+      )
+      response = @context.headers({ 'User-Agent' => user_agent }).operation('listBooks').execute
+      assert_equal '200', response.code
+      assert_equal [1, 2, 3], response.object.map(&:id)
+    end
   end
 
   class BareContextTest < Reynard::Test

--- a/test/reynard_test.rb
+++ b/test/reynard_test.rb
@@ -93,6 +93,10 @@ class ReynardTest < Reynard::Test
     end
   end
 
+  test 'return a User-Agent string with its version' do
+    assert_equal "Reynard/#{Reynard::VERSION}", Reynard.user_agent
+  end
+
   test 'performs a request with a different HTTP implementation' do
     before = Reynard.http
     Reynard.http = Mock.new


### PR DESCRIPTION
Adds an accessor with the proposed User-Agent header value so it's easy for client applications to add additional information if necessary.

Closes #27.