### PR TITLE
Deal with explicit nil values for attributes with an object in the schema

### DIFF
--- a/lib/reynard/model.rb
+++ b/lib/reynard/model.rb
@@ -14,9 +14,17 @@ class Reynard
     end
 
     def initialize(attributes)
-      @attributes = {}
-      @snake_cases = self.class.snake_cases(attributes.keys)
-      self.attributes = attributes
+      if attributes.respond_to?(:each)
+        @attributes = {}
+        @snake_cases = self.class.snake_cases(attributes.keys)
+        self.attributes = attributes
+      else
+        raise(
+          ArgumentError,
+          'Models must be initialized with an enumerable object that behaves like a hash, got: ' \
+          "`#{attributes.inspect}'"
+        )
+      end
     end
 
     def attributes=(attributes)

--- a/lib/reynard/model.rb
+++ b/lib/reynard/model.rb
@@ -47,6 +47,7 @@ class Reynard
     end
 
     def self.cast(name, value)
+      return if value.nil?
       return value unless schema
 
       property = schema.property_schema(name)

--- a/test/reynard/model_test.rb
+++ b/test/reynard/model_test.rb
@@ -50,6 +50,10 @@ class Reynard
     test 'does not build a model for nested resources' do
       assert_kind_of(Hash, @model.address)
     end
+
+    test 'does not attempt to build an object out of nil values' do
+      assert_nil Model.cast('name', nil)
+    end
   end
 
   class AttributeNameModelTest < Reynard::Test
@@ -183,6 +187,10 @@ class Reynard
     test 'builds a model for nested resources' do
       assert_kind_of(Reynard::Models::Author, @model.author)
       assert_equal 'Palin', @model.author.name
+    end
+
+    test 'does not attempt to build an object out of nil values' do
+      assert_nil @model_class.cast('author', nil)
     end
   end
 end

--- a/test/reynard/model_test.rb
+++ b/test/reynard/model_test.rb
@@ -54,6 +54,21 @@ class Reynard
     test 'does not attempt to build an object out of nil values' do
       assert_nil Model.cast('name', nil)
     end
+
+    test 'raises an exception when attempting to build and instance with a nil value' do
+      assert_raises(
+        ArgumentError,
+        "Models must be initialized with an enumerable object that behaves like a hash, got: `nil'"
+      ) do
+        Model.new(nil)
+      end
+    end
+
+    test 'raises an exception when attempting to build and instance with a scalar value' do
+      assert_raises(ArgumentError) { Model.new(nil) }
+      assert_raises(ArgumentError) { Model.new(false) }
+      assert_raises(ArgumentError) { Model.new(12) }
+    end
   end
 
   class AttributeNameModelTest < Reynard::Test


### PR DESCRIPTION
Closes #36.