### PR TITLE
Extend support for schemas with no title property

### DIFF
--- a/lib/reynard/schema.rb
+++ b/lib/reynard/schema.rb
@@ -104,8 +104,14 @@ class Reynard
     end
 
     def node_property_name
-      name = node.at(1).delete_prefix("/")
-      node.last == 'items' ? name.chomp('s') : name
+      base_name = node.at(1).delete_prefix("/")
+      if node.last == 'items'
+        node_name = node.at(-2)
+        base_name.chomp('s') + ' ' + node_name.chomp('s')
+      else
+        node_name = node.last
+        base_name + ' ' + node_name
+      end
     end
   end
 end

--- a/lib/reynard/schema.rb
+++ b/lib/reynard/schema.rb
@@ -104,7 +104,8 @@ class Reynard
     end
 
     def node_property_name
-      node.last == 'items' ? node.at(-2).chomp('s') : node.last
+      name = node.at(1).delete_prefix("/")
+      node.last == 'items' ? name.chomp('s') : name
     end
   end
 end

--- a/test/files/openapi/no_title.yml
+++ b/test/files/openapi/no_title.yml
@@ -1,0 +1,73 @@
+openapi: "3.0.3"
+info:
+  title: Library
+  version: 1.0.0
+  contact: {}
+  description: Unleash imagination, chapter by chapter!
+servers:
+  - url: http://example.com/v1
+tags:
+  - name: chapters
+    description: Chapter related operations
+paths:
+  /chapters:
+    get:
+      summary: List chapters
+      description: List all chapters of a book.
+      operationId: listChapters
+      tags:
+        - chapters
+      responses:
+        "200":
+          description: A list of chapters.
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  type: object
+                  description: Combination of a chapter number and the chapter title.
+                  properties:
+                    number:
+                      type: integer
+                    title:
+                      type: string
+  /sub_chapters:
+    get:
+      summary: List sub-chapters
+      description: List all sub-chapters of a book.
+      operationId: listSubChapters
+      tags:
+        - chapters
+      responses:
+        "200":
+          description: A list of sub-chapters.
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  type: object
+                  title: SubChapter
+                  properties:
+                    title:
+                      type: string
+  /chapter/sample:
+    get:
+      summary: Fetch a random chapter
+      description: Fetch all details for a random chapter.
+      operationId: sampleChapter
+      tags:
+        - chapters
+      responses:
+        "200":
+          description: A chapter.
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  number:
+                    type: integer
+                  title:
+                    type: string

--- a/test/reynard/model_test.rb
+++ b/test/reynard/model_test.rb
@@ -247,7 +247,7 @@ class Reynard
     end
 
     test 'builds a model for nested resources' do
-      assert_kind_of(Reynard::Models::Author, @model.author)
+      assert_kind_of(Reynard::Models::LibraryAuthor, @model.author)
       assert_equal 'Palin', @model.author.name
     end
 

--- a/test/reynard/object_builder_test.rb
+++ b/test/reynard/object_builder_test.rb
@@ -46,6 +46,92 @@ class Reynard
       assert_equal 42, book.id
       assert_equal 'Black Science', book.name
     end
+
+    test "builds a singular record with schema having no title property set" do
+      @specification = Specification.new(filename: fixture_file('openapi/no_title.yml'))
+      operation = @specification.operation('sampleChapter')
+      media_type = @specification.media_type(operation.node, '200', 'application/json')
+      schema = @specification.schema(media_type.node)
+      chapter = Reynard::ObjectBuilder.new(
+        schema: schema,
+        inflector: @inflector,
+        parsed_body: { number: 1, title: 'Echoes of the Void' }
+      ).call
+      assert_model_name('Schema', chapter)
+      assert_equal 1, chapter.number
+      assert_equal 'Echoes of the Void', chapter.title
+    end
+
+    test "raises a TypeError exception when building a collection with schema having no title property set for the list and its elements" do
+      @specification = Specification.new(filename: fixture_file('openapi/no_title.yml'))
+      operation = @specification.operation('listChapters')
+      media_type = @specification.media_type(operation.node, '200', 'application/json')
+      schema = @specification.schema(media_type.node)
+      assert_raises(
+        TypeError,
+        "no implicit conversion of Hash into Integer"
+      ) do
+        Reynard::ObjectBuilder.new(
+          schema: schema,
+          inflector: @inflector,
+          parsed_body: [{ number: 1, title: 'Echoes of the Void' }, { number: 2, title: 'The Alchemy of Shadows' }]
+        ).call
+      end
+    end
+
+    test "raises a TypeError exception when building a singular record with schema having no title property set after building a collection with schema having no $ref property set" do
+      @specification = Specification.new(filename: fixture_file('openapi/no_title.yml'))
+      operation = @specification.operation('listSubChapters')
+      media_type = @specification.media_type(operation.node, '200', 'application/json')
+      schema = @specification.schema(media_type.node)
+      sub_chapters = Reynard::ObjectBuilder.new(
+        schema: schema,
+        inflector: @inflector,
+        parsed_body: [{ number: 1, title: 'Whispers from the Abyss' }, { number: 2, title: 'Harmonics of the Unknown' }]
+      ).call
+      assert_model_name('Schema', sub_chapters)
+
+      operation = @specification.operation('sampleChapter')
+      media_type = @specification.media_type(operation.node, '200', 'application/json')
+      schema = @specification.schema(media_type.node)
+      assert_raises(
+        TypeError,
+        "no implicit conversion of Hash into Integer"
+      ) do
+        Reynard::ObjectBuilder.new(
+          schema: schema,
+          inflector: @inflector,
+          parsed_body: { number: 1, title: 'Echoes of the Void' }
+        ).call
+      end
+    end
+
+    test "raises an ArgumentError exception when building a collection after building a single record with schema having no title property set" do
+      @specification = Specification.new(filename: fixture_file('openapi/no_title.yml'))
+      operation = @specification.operation('sampleChapter')
+      media_type = @specification.media_type(operation.node, '200', 'application/json')
+      schema = @specification.schema(media_type.node)
+      chapter = Reynard::ObjectBuilder.new(
+        schema: schema,
+        inflector: @inflector,
+        parsed_body: { number: 1, title: 'Echoes of the Void' }
+      ).call
+      assert_model_name('Schema', chapter)
+
+      operation = @specification.operation('listSubChapters')
+      media_type = @specification.media_type(operation.node, '200', 'application/json')
+      schema = @specification.schema(media_type.node)
+      assert_raises(
+        ArgumentError,
+        "wrong number of arguments (given 0, expected 1)"
+      ) do
+        Reynard::ObjectBuilder.new(
+          schema: schema,
+          inflector: @inflector,
+          parsed_body: [{ number: 1, title: 'Whispers from the Abyss' }, { number: 2, title: 'Harmonics of the Unknown' }]
+        ).call
+      end
+    end
   end
 
   class ExternalObjectBuilderTest < Reynard::Test

--- a/test/reynard/object_builder_test.rb
+++ b/test/reynard/object_builder_test.rb
@@ -57,7 +57,7 @@ class Reynard
         inflector: @inflector,
         parsed_body: { number: 1, title: 'Echoes of the Void' }
       ).call
-      assert_model_name('ChapterSample', chapter)
+      assert_model_name('ChapterSampleSchema', chapter)
       assert_equal 1, chapter.number
       assert_equal 'Echoes of the Void', chapter.title
     end
@@ -72,16 +72,16 @@ class Reynard
         inflector: @inflector,
         parsed_body: [{ number: 1, title: 'Echoes of the Void' }, { number: 2, title: 'The Alchemy of Shadows' }]
       ).call
-      assert_model_name('Chapters', chapters)
+      assert_model_name('ChaptersSchema', chapters)
       assert_equal 2, chapters.length
 
       chapter = chapters[0]
-      assert_model_name('Chapter', chapter)
+      assert_model_name('ChapterSchema', chapter)
       assert_equal 1, chapter.number
       assert_equal 'Echoes of the Void', chapter.title
 
       chapter = chapters[1]
-      assert_model_name('Chapter', chapter)
+      assert_model_name('ChapterSchema', chapter)
       assert_equal 2, chapter.number
       assert_equal 'The Alchemy of Shadows', chapter.title
     end
@@ -96,7 +96,7 @@ class Reynard
         inflector: @inflector,
         parsed_body: [{ number: 1, title: 'Whispers from the Abyss' }, { number: 2, title: 'Harmonics of the Unknown' }]
       ).call
-      assert_model_name('SubChapters', sub_chapters)
+      assert_model_name('SubChaptersSchema', sub_chapters)
 
       operation = @specification.operation('sampleChapter')
       media_type = @specification.media_type(operation.node, '200', 'application/json')
@@ -106,7 +106,7 @@ class Reynard
         inflector: @inflector,
         parsed_body: { number: 1, title: 'Echoes of the Void' }
       ).call
-      assert_model_name('ChapterSample', chapter)
+      assert_model_name('ChapterSampleSchema', chapter)
     end
 
     test "builds a collection after building a single record with schema having no title property set" do
@@ -119,7 +119,7 @@ class Reynard
         inflector: @inflector,
         parsed_body: { number: 1, title: 'Echoes of the Void' }
       ).call
-      assert_model_name('ChapterSample', chapter)
+      assert_model_name('ChapterSampleSchema', chapter)
 
       operation = @specification.operation('listSubChapters')
       media_type = @specification.media_type(operation.node, '200', 'application/json')
@@ -129,7 +129,7 @@ class Reynard
         inflector: @inflector,
         parsed_body: [{ number: 1, title: 'Whispers from the Abyss' }, { number: 2, title: 'Harmonics of the Unknown' }]
       ).call
-      assert_model_name('SubChapters', sub_chapters)
+      assert_model_name('SubChaptersSchema', sub_chapters)
     end
   end
 
@@ -289,9 +289,10 @@ class Reynard
       ).call
       assert_model_name('Library', library)
       assert_kind_of(Array, library.books)
+      assert_model_name('LibraryBooks', library.books)
       library.books.each do |book|
         assert_model_name('Book', book)
-        assert_model_name('Author', book.author)
+        assert_model_name('LibraryAuthor', book.author)
       end
 
       assert_equal 'Borne', library.books[1].author.name

--- a/test/reynard/object_builder_test.rb
+++ b/test/reynard/object_builder_test.rb
@@ -57,29 +57,36 @@ class Reynard
         inflector: @inflector,
         parsed_body: { number: 1, title: 'Echoes of the Void' }
       ).call
-      assert_model_name('Schema', chapter)
+      assert_model_name('ChapterSample', chapter)
       assert_equal 1, chapter.number
       assert_equal 'Echoes of the Void', chapter.title
     end
 
-    test "raises a TypeError exception when building a collection with schema having no title property set for the list and its elements" do
+    test "builds a collection with schema having no title property set for the list and its elements" do
       @specification = Specification.new(filename: fixture_file('openapi/no_title.yml'))
       operation = @specification.operation('listChapters')
       media_type = @specification.media_type(operation.node, '200', 'application/json')
       schema = @specification.schema(media_type.node)
-      assert_raises(
-        TypeError,
-        "no implicit conversion of Hash into Integer"
-      ) do
-        Reynard::ObjectBuilder.new(
-          schema: schema,
-          inflector: @inflector,
-          parsed_body: [{ number: 1, title: 'Echoes of the Void' }, { number: 2, title: 'The Alchemy of Shadows' }]
-        ).call
-      end
+      chapters = Reynard::ObjectBuilder.new(
+        schema: schema,
+        inflector: @inflector,
+        parsed_body: [{ number: 1, title: 'Echoes of the Void' }, { number: 2, title: 'The Alchemy of Shadows' }]
+      ).call
+      assert_model_name('Chapters', chapters)
+      assert_equal 2, chapters.length
+
+      chapter = chapters[0]
+      assert_model_name('Chapter', chapter)
+      assert_equal 1, chapter.number
+      assert_equal 'Echoes of the Void', chapter.title
+
+      chapter = chapters[1]
+      assert_model_name('Chapter', chapter)
+      assert_equal 2, chapter.number
+      assert_equal 'The Alchemy of Shadows', chapter.title
     end
 
-    test "raises a TypeError exception when building a singular record with schema having no title property set after building a collection with schema having no $ref property set" do
+    test "builds a singular record with schema having no title property set after building a collection with schema having no $ref property set" do
       @specification = Specification.new(filename: fixture_file('openapi/no_title.yml'))
       operation = @specification.operation('listSubChapters')
       media_type = @specification.media_type(operation.node, '200', 'application/json')
@@ -89,24 +96,20 @@ class Reynard
         inflector: @inflector,
         parsed_body: [{ number: 1, title: 'Whispers from the Abyss' }, { number: 2, title: 'Harmonics of the Unknown' }]
       ).call
-      assert_model_name('Schema', sub_chapters)
+      assert_model_name('SubChapters', sub_chapters)
 
       operation = @specification.operation('sampleChapter')
       media_type = @specification.media_type(operation.node, '200', 'application/json')
       schema = @specification.schema(media_type.node)
-      assert_raises(
-        TypeError,
-        "no implicit conversion of Hash into Integer"
-      ) do
-        Reynard::ObjectBuilder.new(
-          schema: schema,
-          inflector: @inflector,
-          parsed_body: { number: 1, title: 'Echoes of the Void' }
-        ).call
-      end
+      chapter = Reynard::ObjectBuilder.new(
+        schema: schema,
+        inflector: @inflector,
+        parsed_body: { number: 1, title: 'Echoes of the Void' }
+      ).call
+      assert_model_name('ChapterSample', chapter)
     end
 
-    test "raises an ArgumentError exception when building a collection after building a single record with schema having no title property set" do
+    test "builds a collection after building a single record with schema having no title property set" do
       @specification = Specification.new(filename: fixture_file('openapi/no_title.yml'))
       operation = @specification.operation('sampleChapter')
       media_type = @specification.media_type(operation.node, '200', 'application/json')
@@ -116,21 +119,17 @@ class Reynard
         inflector: @inflector,
         parsed_body: { number: 1, title: 'Echoes of the Void' }
       ).call
-      assert_model_name('Schema', chapter)
+      assert_model_name('ChapterSample', chapter)
 
       operation = @specification.operation('listSubChapters')
       media_type = @specification.media_type(operation.node, '200', 'application/json')
       schema = @specification.schema(media_type.node)
-      assert_raises(
-        ArgumentError,
-        "wrong number of arguments (given 0, expected 1)"
-      ) do
-        Reynard::ObjectBuilder.new(
-          schema: schema,
-          inflector: @inflector,
-          parsed_body: [{ number: 1, title: 'Whispers from the Abyss' }, { number: 2, title: 'Harmonics of the Unknown' }]
-        ).call
-      end
+      sub_chapters = Reynard::ObjectBuilder.new(
+        schema: schema,
+        inflector: @inflector,
+        parsed_body: [{ number: 1, title: 'Whispers from the Abyss' }, { number: 2, title: 'Harmonics of the Unknown' }]
+      ).call
+      assert_model_name('SubChapters', sub_chapters)
     end
   end
 

--- a/test/reynard/schema_test.rb
+++ b/test/reynard/schema_test.rb
@@ -74,7 +74,6 @@ class Reynard
     test 'returns a schema for its properties' do
       schema = @schema.property_schema('id')
       assert_equal 'integer', schema.type
-      assert_equal 'Id', schema.model_name
     end
 
     test 'does not return a schema for an unknown property' do
@@ -162,25 +161,31 @@ class Reynard
     end
 
     test 'digs into its property schemas' do
+      schema = @schema.property_schema('id')
+      assert_equal 'integer', schema.type
+
       schema = @schema.property_schema('books')
       assert_equal 'array', schema.type
-      assert_equal 'Books', schema.model_name
+      assert_equal 'LibraryBooks', schema.model_name
       assert_equal %w[Library], schema.namespace
 
-      schema = schema.item_schema
-      assert_equal 'object', schema.type
-      assert_equal 'Book', schema.model_name
-      assert_equal %w[Library Books], schema.namespace
+      book_schema = schema.item_schema
+      assert_equal 'object', book_schema.type
+      assert_equal 'Book', book_schema.model_name
+      assert_equal %w[Library LibraryBooks], book_schema.namespace
 
-      schema = schema.property_schema('author')
-      assert_equal 'object', schema.type
-      assert_equal 'Author', schema.model_name
-      assert_equal %w[Library Books Book], schema.namespace
+      schema = book_schema.property_schema('id')
+      assert_equal 'integer', schema.type
+      assert_equal %w[Library LibraryBooks Book], schema.namespace
 
-      schema = schema.property_schema('name')
+      author_schema = book_schema.property_schema('author')
+      assert_equal 'object', author_schema.type
+      assert_equal 'LibraryAuthor', author_schema.model_name
+      assert_equal %w[Library LibraryBooks Book], author_schema.namespace
+
+      schema = author_schema.property_schema('name')
       assert_equal 'string', schema.type
-      assert_equal 'Name', schema.model_name
-      assert_equal %w[Library Books Book Author], schema.namespace
+      assert_equal %w[Library LibraryBooks Book LibraryAuthor], schema.namespace
     end
   end
 end


### PR DESCRIPTION
Our codebase using Reynard has a specification file for API's that we consume; we've encountered several edge cases leading to exceptions, those that can be seen through https://github.com/Manfred/Reynard/commit/4e9bcd0ff13b02d79d3c70d5e679d91d0d744eb6, which disrupts the day-to-day operations of the application.

Ideally, Reynard does not throw exceptions while instantiating model instances when the response schema does not have a title property set, but continues to work as expected.

This PR extends the private method `Reynard::Schema#node_property_name`; it also adds the base node name in the mix to result in a dynamically generated unique model class name (as opposed to a fixed `Schema` class name which would create clashes).