### PR TITLE
Extend support for schemas with `multipart/form-data` content

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,15 @@ response = reynard.
   execute
 ```
 
+When an operation requires `multipart/form-data` content, you can add it as structured data. It will be added as form data automatically.
+
+```ruby
+response = reynard.
+  operation('createEmployee').
+  multipart_form(size: 'large', attachment: attachment).
+  execute
+```
+
 The response object shares much of its interface with `Net::HTTP::Response`.
 
 ```ruby

--- a/lib/reynard/context.rb
+++ b/lib/reynard/context.rb
@@ -39,6 +39,13 @@ class Reynard
       )
     end
 
+    def multipart_form(data)
+      copy(
+        headers: @request_context.headers,
+        form_data: data.map { |key, value| [key.to_s, value] }
+      )
+    end
+
     def headers(headers)
       copy(headers: @request_context.headers.merge(headers))
     end

--- a/lib/reynard/http/request.rb
+++ b/lib/reynard/http/request.rb
@@ -34,6 +34,9 @@ class Reynard
         if @request_context.body
           @request_context.logger&.debug { @request_context.body }
           request.body = @request_context.body
+        elsif @request_context.form_data
+          @request_context.logger&.debug { @request_context.form_data }
+          request.set_form @request_context.form_data, 'multipart/form-data'
         end
         request
       end

--- a/lib/reynard/request_context.rb
+++ b/lib/reynard/request_context.rb
@@ -9,6 +9,7 @@ class Reynard
     :headers,
     :params,
     :body,
+    :form_data,
     keyword_init: true
   ) do
     def verb

--- a/test/files/openapi/simple.yml
+++ b/test/files/openapi/simple.yml
@@ -10,6 +10,8 @@ servers:
 tags:
   - name: books
     description: Book operations
+  - name: book_covers
+    description: Book cover operations
 paths:
   /books:
     get:
@@ -183,6 +185,31 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/Error"
+  /books/covers:
+    post:
+      summary: Create a new book cover.
+      description: Create a new book cover.
+      operationId: createBookCover
+      tags:
+        - book_covers
+      requestBody:
+        content:
+          multipart/form-data:
+            schema:
+              $ref: "#/components/schemas/CreateBookCover"
+      responses:
+        '200':
+          description: A book cover.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/BookCover"
+        default:
+          description: An error.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
 components:
   schemas:
     Book:
@@ -202,6 +229,30 @@ components:
       type: array
       items:
         $ref: "#/components/schemas/Book"
+    CreateBookCover:
+      type: object
+      required:
+        - size
+        - subject
+        - attachment
+      properties:
+        size:
+          type: string
+        subject:
+          type: string
+        attachment:
+          type: string
+          format: binary
+    BookCover:
+      type: object
+      required:
+        - size
+        - subject
+      properties:
+        size:
+          type: string
+        subject:
+          type: string
     Error:
       type: object
       required:

--- a/test/integration/reynard_test.rb
+++ b/test/integration/reynard_test.rb
@@ -48,6 +48,20 @@ module Integration
       end
     end
 
+    test 'uploads a file' do
+      with_simple_service do
+        response = @reynard
+                   .operation('createBookCover')
+                   .multipart_form({ 'size' => 'preview', 'subject' => 'In a Nutshell', 'attachment' => '123' })
+                   .execute
+        assert_equal '200', response.code
+        book_cover = response.object
+        assert_kind_of Reynard::Models::BookCover, book_cover
+        assert_equal 'preview', book_cover.size
+        assert_equal 'In a Nutshell', book_cover.subject
+      end
+    end
+
     test 'returns an error when fetching an object fails' do
       with_simple_service do
         response = @reynard.operation('fetchBook').params(id: -1).execute

--- a/test/reynard/context_test.rb
+++ b/test/reynard/context_test.rb
@@ -115,6 +115,17 @@ class Reynard
       assert_equal 'Howdy', response.object.name
     end
 
+    test 'executes a POST request with a multipart form' do
+      stub_request(:post, 'http://example.com/v1/books/covers').and_return(body: '{"id":1,"name":"Howdy"}')
+      response = @context
+                 .operation('createBookCover')
+                 .multipart_form(name: 'Howdy')
+                 .execute
+      assert_equal '200', response.code
+      assert_equal 1, response.object.id
+      assert_equal 'Howdy', response.object.name
+    end
+
     test 'executes a PUT request with a body' do
       stub_request(:put, 'http://example.com/v1/books/56').and_return(body: '{"id":1,"name":"Howdy"}')
       response = @context.operation('updateBook').params(id: 56).body(name: 'Howdy').execute

--- a/test/reynard/request_context_test.rb
+++ b/test/reynard/request_context_test.rb
@@ -106,7 +106,8 @@ class Reynard
         operation: @specification.operation('fetchBook'),
         headers: { 'Accept' => 'application/json' },
         params: { 'path' => { 'id' => 12 }, 'query' => { 'format' => 'csv' } },
-        body: '{}'
+        body: '{}',
+        form_data: '{}'
       }
       copy = @request_context.copy(**properties)
       properties.each do |name, value|

--- a/test/support/simple_service.rb
+++ b/test/support/simple_service.rb
@@ -15,12 +15,15 @@ class SimpleService
       @books = [
         { 'id' => 1 }
       ]
+      @book_covers = []
     end
 
     def service(http_request, http_response)
       case http_request.path
       when '/books'
-        handle_collection(http_request, http_response)
+        handle_book_collection(http_request, http_response)
+      when '/books/covers'
+        handle_book_cover_collection(http_request, http_response)
       when %r{/books/(\d+)}
         handle_member(Regexp.last_match(1).to_i, http_response)
       else
@@ -30,14 +33,19 @@ class SimpleService
 
     private
 
-    def handle_collection(http_request, http_response)
+    def handle_book_collection(http_request, http_response)
       case http_request.request_method
       when 'GET'
         http_response.body = MultiJson.dump(all)
       when 'POST'
-        book = add(MultiJson.load(http_request.body))
+        book = add_book(MultiJson.load(http_request.body))
         http_response.body = MultiJson.dump(book)
       end
+    end
+
+    def handle_book_cover_collection(http_request, http_response)
+      book_cover = add_book_cover(http_request.query)
+      http_response.body = MultiJson.dump(book_cover)
     end
 
     def handle_member(id, http_response)
@@ -62,9 +70,14 @@ class SimpleService
       @books.find { |book| book['id'] == id }
     end
 
-    def add(attributes)
+    def add_book(attributes)
       @books << attributes.merge('id' => @books.map { |book| book['id'] }.max.to_i + 1)
       @books.last
+    end
+
+    def add_book_cover(attributes)
+      @book_covers << attributes.except("attachment")
+      @book_covers.last
     end
   end
 


### PR DESCRIPTION
Added `Reynard::Context#multipart_form` so consumers can pass form data to upload files.