### PR TITLE
Update model naming for arrays and refactor

### DIFF
--- a/lib/reynard/schema.rb
+++ b/lib/reynard/schema.rb
@@ -46,37 +46,6 @@ class Reynard
       )
     end
 
-    def self.title_model_name(model_name)
-      return unless model_name
-
-      model_name
-        .gsub(/[^[:alpha:]]/, ' ')
-        .gsub(/\s{2,}/, ' ')
-        .gsub(/(\s+)([[:alpha:]])/) { Regexp.last_match(2).upcase }
-        .strip
-    end
-
-    # Extracts a model name from a ref when there is a usable value.
-    #
-    #   ref_model_name("#/components/schemas/Library") => "Library"
-    def self.ref_model_name(ref)
-      return unless ref
-
-      normalize_ref_model_name(ref.split('/')&.last)
-    end
-
-    def self.normalize_ref_model_name(model_name)
-      # 1. Unescape encoded characters to create an UTF-8 string
-      # 2. Remove extensions for regularly used external schema files
-      # 3. Replace all non-alphabetic characters with a space (not allowed in Ruby constant)
-      # 4. Camelcase
-      Rack::Utils.unescape_path(model_name)
-                 .gsub(/(.yml|.yaml|.json)\Z/, '')
-                 .gsub(/[^[:alpha:]]/, ' ')
-                 .gsub(/(\s+)([[:alpha:]])/) { Regexp.last_match(2).upcase }
-                 .gsub(/\A(.)/) { Regexp.last_match(1).upcase }
-    end
-
     private
 
     def model_naming

--- a/lib/reynard/schema/model_naming.rb
+++ b/lib/reynard/schema/model_naming.rb
@@ -1,0 +1,109 @@
+# frozen_string_literal: true
+
+class Reynard
+  class Schema
+    # Rummages through the specification to find a suitable model name for a response object.
+    class ModelNaming
+      def initialize(specification:, node:)
+        @specification = specification
+        @node = node
+      end
+
+      def model_name
+        title_model_name || ref_model_name || node_model_name
+      end
+
+      def self.title_model_name(model_name)
+        return unless model_name
+
+        model_name
+          .gsub(/[^[:alpha:]]/, ' ')
+          .gsub(/\s{2,}/, ' ')
+          .gsub(/(\s+)([[:alpha:]])/) { Regexp.last_match(2).upcase }
+          .strip
+      end
+
+      # Extracts a model name from a ref when there is a usable value.
+      #
+      #   ref_model_name("#/components/schemas/Library") => "Library"
+      def self.ref_model_name(ref)
+        return unless ref
+
+        normalize_ref_model_name(ref.split('/')&.last)
+      end
+
+      def self.normalize_ref_model_name(model_name)
+        # 1. Unescape encoded characters to create an UTF-8 string
+        # 2. Remove extensions for regularly used external schema files
+        # 3. Replace all non-alphabetic characters with a space (not allowed in Ruby constant)
+        # 4. Camelcase
+        Rack::Utils.unescape_path(model_name)
+                   .gsub(/(.yml|.yaml|.json)\Z/, '')
+                   .gsub(/[^[:alpha:]]/, ' ')
+                   .gsub(/(\s+)([[:alpha:]])/) { Regexp.last_match(2).upcase }
+                   .gsub(/\A(.)/) { Regexp.last_match(1).upcase }
+      end
+
+      def self.singularize(name)
+        name.chomp('s')
+      end
+
+      private
+
+      # Returns a model name when it was explicitly set using the title property in the specification.
+      def title_model_name
+        title = @specification.dig(*@node, 'title')
+        return unless title
+
+        self.class.title_model_name(title)
+      end
+
+      # Returns a model name based on the schema's $ref value, usually this contains a usable
+      # identifier at the end like /books.yml or /Books.
+      def ref_model_name
+        parent = @specification.dig(*@node[..-2])
+        ref = parent.dig('schema', '$ref') || parent.dig('items', '$ref')
+        return unless ref
+
+        self.class.ref_model_name(ref)
+      end
+
+      # Returns a model name based on the node path to schema in the specification.
+      def node_model_name
+        self.class.title_model_name(node_path_name.capitalize.gsub(/[_-]/, ' '))
+      end
+
+      def node_path_name
+        if node_anyonymous?
+          request_path_model_name
+        elsif @node.last == 'items'
+          # Use the property name as the model name for its items, for example in the case of
+          # schema > properties > birds > items => bird.
+          self.class.singularize(@node.at(-2))
+        else
+          # Usually this means we are dealing with a property's name a not a model, for example in
+          # the case of schema > properties > color => color.
+          @node.last
+        end
+      end
+
+      # Returns true when the node path doesn't have identifyable segments other than the request
+      # path for the resource.
+      #
+      # For example, when the last part of the path looks like this:
+      #   get > responses > 200 > content > application|json > schema
+      def node_anyonymous?
+        @node.last == 'schema' || @node.last(2) == %w[schema items]
+      end
+
+      # Finds the first segment starting from the end of the request path that is not a parameter
+      # and transforms that to make a model name.
+      #
+      # For example:
+      #   /books/{id} => "book"
+      def request_path_model_name
+        self.class.singularize(@node[1].split('/').reverse.find { |part| !part.start_with?('{') })
+      end
+    end
+  end
+end

--- a/lib/reynard/schema/model_naming.rb
+++ b/lib/reynard/schema/model_naming.rb
@@ -45,7 +45,12 @@ class Reynard
       end
 
       def self.singularize(name)
-        name.chomp('s')
+        case name
+        when /ies$/
+          "#{name[0..-4]}y"
+        else
+          name.chomp('s')
+        end
       end
 
       private

--- a/lib/reynard/schema/model_naming.rb
+++ b/lib/reynard/schema/model_naming.rb
@@ -10,7 +10,12 @@ class Reynard
       end
 
       def model_name
-        title_model_name || ref_model_name || node_model_name
+        model_name = determine_model_name
+        if class_type == :array
+          "#{model_name}Collection"
+        else
+          model_name
+        end
       end
 
       def self.title_model_name(model_name)
@@ -54,6 +59,14 @@ class Reynard
       end
 
       private
+
+      def class_type
+        @specification.dig(*@node).key?('items') ? :array : :object
+      end
+
+      def determine_model_name
+        title_model_name || ref_model_name || node_model_name
+      end
 
       # Returns a model name when it was explicitly set using the title property in the specification.
       def title_model_name

--- a/lib/reynard/specification.rb
+++ b/lib/reynard/specification.rb
@@ -5,6 +5,8 @@ require 'rack'
 class Reynard
   # Wraps the YAML representation of an OpenAPI specification.
   class Specification
+    autoload :Query, 'reynard/specification/query'
+
     VERBS = %w[get put post delete options head patch trace].freeze
 
     def initialize(filename:)

--- a/lib/reynard/specification.rb
+++ b/lib/reynard/specification.rb
@@ -20,6 +20,15 @@ class Reynard
       dig_into(@data, @data, path.dup, File.dirname(@filename))
     end
 
+    # Yields all nodes in the specification matching the specified type.
+    #
+    #   specification.find_each(type: 'object') {}
+    #
+    # Please don't use this in a hot paths in production, primarily meant for testing and tooling.
+    def find_each(type:, &block)
+      Finder.new(specification: self, query: Query.new(type: type)).find_each(&block)
+    end
+
     def servers
       dig('servers').map { |attributes| Server.new(attributes) }
     end

--- a/lib/reynard/specification.rb
+++ b/lib/reynard/specification.rb
@@ -5,6 +5,7 @@ require 'rack'
 class Reynard
   # Wraps the YAML representation of an OpenAPI specification.
   class Specification
+    autoload :Finder, 'reynard/specification/finder'
     autoload :Query, 'reynard/specification/query'
 
     VERBS = %w[get put post delete options head patch trace].freeze

--- a/lib/reynard/specification/finder.rb
+++ b/lib/reynard/specification/finder.rb
@@ -1,0 +1,31 @@
+# frozen_string_literal: true
+
+class Reynard
+  class Specification
+    # Finds nodes in a specification that match a query.
+    class Finder
+      def initialize(specification:, query:)
+        @specification = specification
+        @query = query
+      end
+
+      def find_each(&block)
+        find_into([], &block)
+      end
+
+      private
+
+      def find_into(path, &block)
+        data = @specification.dig(*path)
+
+        yield path if data.respond_to?(:key?) && (data.key?('type') && (@query.type == data['type']))
+
+        return unless data.respond_to?(:each_key)
+
+        data.each_key do |key|
+          find_into([*path, key], &block)
+        end
+      end
+    end
+  end
+end

--- a/lib/reynard/specification/query.rb
+++ b/lib/reynard/specification/query.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+class Reynard
+  class Specification
+    # Describes a query for a node in a specification.
+    class Query
+      attr_reader :type
+
+      def initialize(type: nil)
+        @type = type
+      end
+    end
+  end
+end

--- a/test/files/openapi/naming.yml
+++ b/test/files/openapi/naming.yml
@@ -1,0 +1,104 @@
+openapi: "3.1.0"
+info:
+  title: Industry classification
+  version: 1.0.0
+  contact: {}
+  description: Uses industry classification example to show model naming based on schema.
+servers:
+  - url: https://example.com
+tags:
+  - name: naics
+    description: Classification System
+paths:
+  /sectors:
+    get:
+      summary: Get all sectors
+      description: Returns the entire taxonomy for the classification system.
+      operationId: getSectors
+      tags:
+        - naics
+      responses:
+        "200":
+          description: Entire tree of all sectors and their taxonomy.
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  type: object
+                  properties:
+                    id:
+                      type: integer
+                    name:
+                      type: string
+                    subsectors:
+                      type: array
+                      items:
+                        type: object
+                        properties:
+                          name:
+                            type: string
+                          industry_groups:
+                            type: array
+                            items:
+                              type: object
+                              properties:
+                                name:
+                                  type: string
+                                industries:
+                                  type: array
+                                  items:
+                                    type: object
+                                    properties:
+                                      name:
+                                        type: string
+                                      national_industries:
+                                        type: array
+                                        items:
+                                          type: object
+                                          properties:
+                                            label:
+                                              type: string
+  /sectors/arts:
+    get:
+      summary: Get all the sectors within the arts.
+      description: Returns a list of all national industries.
+      operationId: getArtsSectors
+      tags:
+        - naics
+      responses:
+        "200":
+          description: List of national industies.
+          content:
+            application/json:
+              schema:
+                type: array
+                title: NationalIndustry
+                items:
+                  type: object
+                  properties:
+                    id:
+                      type: integer
+                    label:
+                      type: string
+  /national_industries:
+    get:
+      summary: Get all national industries.
+      description: Returns a list of all national industries.
+      operationId: getNationalIndustries
+      tags:
+        - naics
+      responses:
+        "200":
+          description: List of national industies.
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  type: object
+                  properties:
+                    id:
+                      type: integer
+                    label:
+                      type: string

--- a/test/files/openapi/simple.yml
+++ b/test/files/openapi/simple.yml
@@ -26,7 +26,7 @@ paths:
           schema:
             type: string
       responses:
-        '200':
+        "200":
           description: An array of books.
           content:
             application/json:
@@ -49,8 +49,14 @@ paths:
           application/json:
             schema:
               $ref: "#/components/schemas/Book"
+          multipart/form-data:
+            schema:
+              $ref: "#/components/schemas/BookFormData"
+          text/plain:
+            schema:
+              type: string
       responses:
-        '200':
+        "200":
           description: A book.
           content:
             application/json:
@@ -77,7 +83,7 @@ paths:
           schema:
             type: integer
       responses:
-        '200':
+        "200":
           description: A book.
           content:
             application/json:
@@ -103,7 +109,7 @@ paths:
           schema:
             type: integer
       responses:
-        '200':
+        "200":
           description: A book.
           content:
             application/json:
@@ -132,7 +138,7 @@ paths:
           schema:
             type: integer
       responses:
-        '204':
+        "204":
           description: Book was deleted.
         default:
           description: Book was deleted.
@@ -144,7 +150,7 @@ paths:
       tags:
         - books
       responses:
-        '200':
+        "200":
           description: A book.
           content:
             application/json:
@@ -171,7 +177,7 @@ paths:
           schema:
             type: string
       responses:
-        '200':
+        "200":
           description: An array of books.
           content:
             application/json:
@@ -198,6 +204,22 @@ components:
           type: string
         tag:
           type: string
+    BookFormData:
+      type: object
+      required:
+        - id
+        - name
+      properties:
+        id:
+          type: integer
+          format: int64
+        name:
+          type: string
+        tag:
+          type: string
+        image:
+          type: string
+          format: binary
     Books:
       type: array
       items:

--- a/test/files/openapi/weird.yml
+++ b/test/files/openapi/weird.yml
@@ -25,7 +25,7 @@ paths:
           schema:
             type: string
       responses:
-        '200':
+        "200":
           description: A clown.
           content:
             application/json:
@@ -39,7 +39,7 @@ paths:
       tags:
         - complex
       responses:
-        '200':
+        "200":
           description: " it's not empty 🚕"
           content:
             application/json:
@@ -49,6 +49,70 @@ paths:
                 properties:
                   name:
                     type: string
+  /fugol:
+    get:
+      description: Get all fugol
+      operationId: fetchFugol
+      tags:
+        - complex
+      responses:
+        "200":
+          description: Success!
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  type: object
+                  properties:
+                    birds:
+                      type: array
+                      items:
+                        type: object
+                        properties:
+                          name:
+                            type: string
+  /duckbills:
+    get:
+      description: Get all duckbills
+      operationId: fetchDuckbills
+      tags:
+        - complex
+      responses:
+        "200":
+          description: Success!
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  type: object
+                  properties:
+                    color:
+                      type: integer
+  /duckbills/{id}:
+    get:
+      description: Get a duckbill
+      operationId: fetchDuckbill
+      tags:
+        - complex
+      parameters:
+        - name: id
+          in: path
+          description: Identifier for the duckbill.
+          required: true
+          schema:
+            type: integer
+      responses:
+        "200":
+          description: Success!
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  color:
+                    type: integer
 components:
   schemas:
     " howdy⚠️.Pardner":
@@ -58,4 +122,3 @@ components:
       properties:
         placeholder:
           type: string
-

--- a/test/integration/reynard_test.rb
+++ b/test/integration/reynard_test.rb
@@ -24,7 +24,7 @@ module Integration
         response = @reynard.operation('listBooks').execute
         assert_equal '200', response.code
         books = response.object
-        assert_kind_of Reynard::Models::Books, books
+        assert_kind_of Reynard::Models::BooksCollection, books
       end
     end
 

--- a/test/reynard/schema/model_naming_test.rb
+++ b/test/reynard/schema/model_naming_test.rb
@@ -76,7 +76,7 @@ class Reynard
 
       test 'formats a model name based on the node to the schema' do
         assert_equal(
-          'NationalIndustry',
+          'NationalIndustryCollection',
           ModelNaming.new(
             specification: @specification,
             node: @node
@@ -130,15 +130,13 @@ class Reynard
         ]
 
         assert_equal(
-          'Sector',
+          'SectorCollection',
           ModelNaming.new(
             specification: @specification,
             node: node
           ).model_name
         )
-      end
 
-      test 'formats a model name based on the node to the schemas' do
         node = %w[
           paths
           /national_industries
@@ -151,7 +149,29 @@ class Reynard
         ]
 
         assert_equal(
-          'NationalIndustrie',
+          'NationalIndustryCollection',
+          ModelNaming.new(
+            specification: @specification,
+            node: node
+          ).model_name
+        )
+      end
+
+      test 'formats a model name for an array item' do
+        node = %w[
+          paths
+          /sectors
+          get
+          responses
+          200
+          content
+          application/json
+          schema
+          items
+        ]
+
+        assert_equal(
+          'Sector',
           ModelNaming.new(
             specification: @specification,
             node: node

--- a/test/reynard/schema/model_naming_test.rb
+++ b/test/reynard/schema/model_naming_test.rb
@@ -35,6 +35,16 @@ class Reynard
         assert_nil ModelNaming.ref_model_name(nil)
       end
 
+      test 'singularizes strings' do
+        [
+          %w[model model],
+          %w[ducks duck],
+          %w[industries industry]
+        ].each do |input, expected|
+          assert_equal expected, ModelNaming.singularize(input)
+        end
+      end
+
       test 'produces a model name for every schema node in every specification' do
         Dir.glob(File.join(FILES_ROOT, 'openapi/*.yml')).map do |filename|
           specification = Specification.new(filename: filename)

--- a/test/reynard/schema/model_naming_test.rb
+++ b/test/reynard/schema/model_naming_test.rb
@@ -1,0 +1,227 @@
+# frozen_string_literal: true
+
+require_relative '../../test_helper'
+
+class Reynard
+  class Schema
+    class ModelNamingTest < Reynard::Test
+      test 'formats a model name based on the title specification' do
+        {
+          'AdministrationAgreement' => 'AdministrationAgreement',
+          'Library' => 'Library',
+          'ISBN' => 'ISBN',
+          ' A %2F root with 🚕 in the ' => 'AFRootWithInThe'
+        }.each do |model_name, expected|
+          assert_equal expected, ModelNaming.title_model_name(model_name)
+        end
+      end
+
+      test 'does not return a model name based on a missing title' do
+        assert_nil ModelNaming.title_model_name(nil)
+      end
+
+      test 'formats a model name based on a ref to a schema' do
+        {
+          '#/components/schemas/Library' => 'Library',
+          './schemas/author.yml' => 'Author',
+          '#/components/schemas/%20howdy%E2%9A%A0%EF%B8%8F.Pardner' => 'HowdyPardner',
+          '#/components/schemas/Service.Subscription' => 'ServiceSubscription'
+        }.each do |ref, expected|
+          assert_equal expected, ModelNaming.ref_model_name(ref)
+        end
+      end
+
+      test 'does not return a model name based on a missing ref' do
+        assert_nil ModelNaming.ref_model_name(nil)
+      end
+
+      test 'produces a model name for every schema node in every specification' do
+        Dir.glob(File.join(FILES_ROOT, 'openapi/*.yml')).map do |filename|
+          specification = Specification.new(filename: filename)
+          specification.find_each(type: 'object') do |node|
+            naming = ModelNaming.new(specification: specification, node: node)
+            model_name = naming.model_name
+            refute_nil model_name
+            assert_kind_of(String, model_name)
+            assert model_name.size > 2, model_name
+          end
+        end
+      end
+    end
+
+    class TitleModelNamingTest < Reynard::Test
+      def setup
+        @specification = Specification.new(filename: fixture_file('openapi/naming.yml'))
+        @node = %w[
+          paths
+          /sectors/arts
+          get
+          responses
+          200
+          content
+          application/json
+          schema
+        ]
+      end
+
+      test 'formats a model name based on the node to the schema' do
+        assert_equal(
+          'NationalIndustry',
+          ModelNaming.new(
+            specification: @specification,
+            node: @node
+          ).model_name
+        )
+      end
+    end
+
+    class RefModelNamingTest < Reynard::Test
+      def setup
+        @specification = Specification.new(filename: fixture_file('openapi/simple.yml'))
+      end
+
+      test 'formats a model name based on the ref to the schema' do
+        node = %w[
+          paths
+          /books/{id}
+          get
+          responses
+          200
+          content
+          application/json
+          schema
+        ]
+
+        assert_equal(
+          'Book',
+          ModelNaming.new(
+            specification: @specification,
+            node: node
+          ).model_name
+        )
+      end
+    end
+
+    class ModelNamingTest < Reynard::Test
+      def setup
+        @specification = Specification.new(filename: fixture_file('openapi/naming.yml'))
+      end
+
+      test 'formats a model name based on the node to the schema' do
+        node = %w[
+          paths
+          /sectors
+          get
+          responses
+          200
+          content
+          application/json
+          schema
+        ]
+
+        assert_equal(
+          'Sector',
+          ModelNaming.new(
+            specification: @specification,
+            node: node
+          ).model_name
+        )
+      end
+
+      test 'formats a model name based on the node to the schemas' do
+        node = %w[
+          paths
+          /national_industries
+          get
+          responses
+          200
+          content
+          application/json
+          schema
+        ]
+
+        assert_equal(
+          'NationalIndustrie',
+          ModelNaming.new(
+            specification: @specification,
+            node: node
+          ).model_name
+        )
+      end
+    end
+
+    class SpecialModelNamingTest < Reynard::Test
+      def setup
+        @specification = Specification.new(filename: fixture_file('openapi/weird.yml'))
+      end
+
+      test 'formats a model name based on property name for an array item' do
+        node = %w[
+          paths
+          /fugol
+          get
+          responses
+          200
+          content
+          application/json
+          schema
+          items
+          properties
+          birds
+          items
+        ]
+
+        assert_equal(
+          'Bird',
+          ModelNaming.new(
+            specification: @specification,
+            node: node
+          ).model_name
+        )
+      end
+
+      test 'formats a model name based on the request path when node has no property name' do
+        node = %w[
+          paths
+          /duckbills/{id}
+          get
+          responses
+          200
+          content
+          application/json
+          schema
+        ]
+
+        assert_equal(
+          'Duckbill',
+          ModelNaming.new(
+            specification: @specification,
+            node: node
+          ).model_name
+        )
+      end
+
+      test 'formats a model name based on the request path when array item has no property name' do
+        node = %w[
+          paths
+          /duckbills
+          get
+          responses
+          200
+          content
+          application/json
+          schema
+          items
+        ]
+
+        assert_equal(
+          'Duckbill',
+          ModelNaming.new(
+            specification: @specification,
+            node: node
+          ).model_name
+        )
+      end
+    end
+  end
+end

--- a/test/reynard/schema_test.rb
+++ b/test/reynard/schema_test.rb
@@ -81,7 +81,7 @@ class Reynard
     end
 
     test 'formats a model name and namespace' do
-      assert_equal 'Books', @schema.model_name
+      assert_equal 'BooksCollection', @schema.model_name
       assert_nil @schema.namespace
     end
 
@@ -135,23 +135,23 @@ class Reynard
     test 'digs into its property schemas' do
       schema = @schema.property_schema('books')
       assert_equal 'array', schema.type
-      assert_equal 'Books', schema.model_name
+      assert_equal 'BooksCollection', schema.model_name
       assert_equal %w[Library], schema.namespace
 
       schema = schema.item_schema
       assert_equal 'object', schema.type
       assert_equal 'Book', schema.model_name
-      assert_equal %w[Library Books], schema.namespace
+      assert_equal %w[Library BooksCollection], schema.namespace
 
       schema = schema.property_schema('author')
       assert_equal 'object', schema.type
       assert_equal 'Author', schema.model_name
-      assert_equal %w[Library Books Book], schema.namespace
+      assert_equal %w[Library BooksCollection Book], schema.namespace
 
       schema = schema.property_schema('name')
       assert_equal 'string', schema.type
       assert_equal 'Name', schema.model_name
-      assert_equal %w[Library Books Book Author], schema.namespace
+      assert_equal %w[Library BooksCollection Book Author], schema.namespace
     end
   end
 end

--- a/test/reynard/schema_test.rb
+++ b/test/reynard/schema_test.rb
@@ -4,35 +4,6 @@ require_relative '../test_helper'
 
 class Reynard
   class SchemaTest < Reynard::Test
-    test 'formats a model name based on the title specification' do
-      {
-        'AdministrationAgreement' => 'AdministrationAgreement',
-        'Library' => 'Library',
-        'ISBN' => 'ISBN',
-        ' A %2F root with 🚕 in the ' => 'AFRootWithInThe'
-      }.each do |model_name, expected|
-        assert_equal expected, Schema.title_model_name(model_name)
-      end
-    end
-
-    test 'does not return a model name based on a missing title' do
-      assert_nil Schema.title_model_name(nil)
-    end
-
-    test 'formats a model name based on a ref to a schema' do
-      {
-        '#/components/schemas/Library' => 'Library',
-        './schemas/author.yml' => 'Author',
-        '#/components/schemas/%20howdy%E2%9A%A0%EF%B8%8F.Pardner' => 'HowdyPardner',
-        '#/components/schemas/Service.Subscription' => 'ServiceSubscription'
-      }.each do |ref, expected|
-        assert_equal expected, Schema.ref_model_name(ref)
-      end
-    end
-
-    test 'does not return a model name based on a missing ref' do
-      assert_nil Schema.ref_model_name(nil)
-    end
   end
 
   class SingularTopLevelSchemaTest < Reynard::Test

--- a/test/reynard/specification/finder_test.rb
+++ b/test/reynard/specification/finder_test.rb
@@ -1,0 +1,53 @@
+# frozen_string_literal: true
+
+require_relative '../../test_helper'
+
+class Reynard
+  class Specification
+    class FinderTest < Reynard::Test
+      def setup
+        @specification = Specification.new(filename: fixture_file('openapi/simple.yml'))
+      end
+
+      test 'finds all nodes in a specification that match a type' do
+        query = Query.new(type: 'object')
+        finder = Finder.new(specification: @specification, query: query)
+        found = []
+        finder.find_each do |node|
+          found << node.join('::')
+        end
+        assert_equal(
+          [
+            'paths::/books::get::responses::200::content::application/json::schema::items',
+            'paths::/books::get::responses::default::content::application/json::schema',
+            'paths::/books::post::requestBody::content::application/json::schema',
+            'paths::/books::post::requestBody::content::multipart/form-data::schema',
+            'paths::/books::post::responses::200::content::application/json::schema',
+            'paths::/books::post::responses::default::content::application/json::schema',
+            'paths::/books/{id}::get::responses::200::content::application/json::schema',
+            'paths::/books/{id}::get::responses::default::content::application/json::schema',
+            'paths::/books/{id}::put::responses::200::content::application/json::schema',
+            'paths::/books/{id}::put::responses::default::content::application/json::schema',
+            'paths::/books/{id}::patch::responses::200::content::application/json::schema',
+            'paths::/books/{id}::patch::responses::default::content::application/json::schema',
+            'paths::/books/sample::get::responses::200::content::application/json::schema',
+            'paths::/books/sample::get::responses::default::content::application/json::schema',
+            'paths::/search/books::get::responses::200::content::application/json::schema::items',
+            'paths::/search/books::get::responses::default::content::application/json::schema',
+            'components::schemas::Book',
+            'components::schemas::BookFormData',
+            'components::schemas::Books::items',
+            'components::schemas::Error'
+          ],
+          found
+        )
+      end
+
+      test 'does not find nodes for query without match' do
+        query = Query.new(type: 'unknown')
+        finder = Finder.new(specification: @specification, query: query)
+        finder.find_each { raise 'Must not find anything' }
+      end
+    end
+  end
+end

--- a/test/reynard/specification/query_test.rb
+++ b/test/reynard/specification/query_test.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+require_relative '../../test_helper'
+
+class Reynard
+  class Specification
+    class QueryTest < Reynard::Test
+      test 'represents a query for a type node in a specification' do
+        query = Query.new(type: 'object')
+        assert_equal 'object', query.type
+      end
+    end
+  end
+end

--- a/test/reynard/specification_test.rb
+++ b/test/reynard/specification_test.rb
@@ -30,6 +30,21 @@ class Reynard
       )
     end
 
+    test 'finds each node with a specified type in the specification' do
+      found = false
+      @specification.find_each(type: 'object') do |node|
+        found = true
+        assert_equal('object', @specification.dig(*node)['type'])
+      end
+      assert found
+    end
+
+    test 'does not find nodes with non-existent type' do
+      @specification.find_each(type: 'non-existent') do
+        raise 'Must not find anything'
+      end
+    end
+
     test 'returns servers' do
       assert_equal(
         %w[

--- a/test/reynard/specification_test.rb
+++ b/test/reynard/specification_test.rb
@@ -152,7 +152,7 @@ class Reynard
         schema.node
       )
       assert_equal('array', schema.type)
-      assert_equal('Books', schema.model_name)
+      assert_equal('BooksCollection', schema.model_name)
       assert_equal('Book', schema.item_schema.model_name)
 
       operation = @specification.operation('fetchBook')
@@ -176,7 +176,7 @@ class Reynard
         schema.node
       )
       assert_equal('array', schema.type)
-      assert_equal('Books', schema.model_name)
+      assert_equal('BooksCollection', schema.model_name)
       assert_equal('Book', schema.item_schema.model_name)
 
       operation = @specification.operation('fetchBook')


### PR DESCRIPTION
* Changes model naming so the model name for a collection doesn't conflict with its items.

An array could previously get the same model name as its items and that would result in an exception `TypeError: no implicit conversion of Hash into Integer` because we would attempt to initialize an Array subclass with a Hash of attributes.

This PR changes the logic to add `Collection` to the array model name, eg. `BooksCollection` so it doesn't conflict with the item model name, eg. `Book`.

References #52.