### PR TITLE
Improve $ref resolving

### DIFF
--- a/lib/reynard/external.rb
+++ b/lib/reynard/external.rb
@@ -3,9 +3,16 @@
 require 'rack'
 
 class Reynard
-  # Loads external references.
+  # Loads data for external references from disk.
   class External
-    def initialize(path:, ref:)
+    # Build a new external reference loader.
+    #
+    # @param basepath [String] base path of the OpenAPI specification, we never load any files
+    #        higher in the directory tree
+    # @param path [String] base path of the current file, used to resolve relative paths
+    # @param ref [String] the $ref value we actually resolve
+    def initialize(basepath:, path:, ref:)
+      @basepath = basepath
       @path = path
       @relative_path, @anchor = ref.split('#', 2)
       @filename = File.expand_path(@relative_path, @path)
@@ -30,7 +37,7 @@ class Reynard
     private
 
     def filename
-      return @filename if @filename.start_with?(@path)
+      return @filename if @filename.start_with?(@basepath)
 
       raise 'You are only allowed to reference files relative to the specification file.'
     end

--- a/lib/reynard/specification.rb
+++ b/lib/reynard/specification.rb
@@ -113,7 +113,6 @@ class Reynard
     end
 
     # rubocop:disable Metrics/AbcSize
-    # rubocop:disable Metrics/CyclomaticComplexity
     # rubocop:disable Metrics/MethodLength
     def dig_into(data, cursor, path, filesystem_path)
       while path.length.positive?
@@ -129,8 +128,8 @@ class Reynard
           path = Rack::Utils.unescape_path(cursor['$ref'][2..]).split('/') + path
           cursor = data
         # References another file, with an optional anchor to an element in the data.
-        when %r{\A\./}
-          external = External.new(path: filesystem_path, ref: cursor['$ref'])
+        else
+          external = External.new(basepath:, path: filesystem_path, ref: cursor['$ref'])
           filesystem_path = external.filesystem_path
           path = external.path + path
           cursor = external.data
@@ -139,7 +138,10 @@ class Reynard
       cursor
     end
     # rubocop:enable Metrics/AbcSize
-    # rubocop:enable Metrics/CyclomaticComplexity
     # rubocop:enable Metrics/MethodLength
+
+    def basepath
+      File.dirname(File.expand_path(@filename))
+    end
   end
 end

--- a/test/files/openapi/external.yml
+++ b/test/files/openapi/external.yml
@@ -26,15 +26,29 @@ paths:
           schema:
             type: integer
       responses:
-        '200':
+        "200":
           description: A author.
           content:
             application/json:
               schema:
-                $ref: './schemas/author.yml'
+                $ref: "./schemas/author.yml"
         default:
           description: An error.
           content:
             application/json:
               schema:
                 $ref: "./simple.yml#/components/schemas/Error"
+  /authors/me:
+    get:
+      summary: Fetch own author profile
+      description: Fetch all details for own author profile
+      operationId: fetchAuthenticatedAuthor
+      tags:
+        - authors
+      responses:
+        "200":
+          description: A author.
+          content:
+            application/json:
+              schema:
+                $ref: "schemas/author.yml"

--- a/test/reynard/external_test.rb
+++ b/test/reynard/external_test.rb
@@ -6,25 +6,41 @@ class Reynard
   class ExternalTest < Reynard::Test
     test 'raises an exception when attempting to access a file not relative to specification' do
       assert_raises(RuntimeError) do
-        External.new(path: FILES_ROOT, ref: '../../../passwords.txt').data
+        External.new(basepath: FILES_ROOT, path: FILES_ROOT, ref: '../../../passwords.txt').data
       end
     end
 
-    test 'loads data from a schema relative to a specification' do
+    test 'loads data from a schema relative to the current path' do
+      basepath = File.join(FILES_ROOT, 'openapi')
+      path = File.join(FILES_ROOT, 'openapi/schemas')
+
+      data = External.new(basepath:, path:, ref: 'author.yml').data
+      assert_equal 'Author', data['title']
+    end
+
+    test 'loads data from a schema with an explicity relative path' do
       path = File.join(FILES_ROOT, 'openapi')
-      data = External.new(path:, ref: './schemas/author.yml').data
+      data = External.new(basepath: path, path:, ref: './schemas/author.yml').data
+      assert_equal 'Author', data['title']
+    end
+
+    test 'loads data from a schema with a relative path higher in the directory structure' do
+      basepath = File.join(FILES_ROOT, 'openapi')
+      path = File.join(FILES_ROOT, 'openapi/schemas/v1/home')
+
+      data = External.new(basepath:, path:, ref: '../../../schemas/author.yml').data
       assert_equal 'Author', data['title']
     end
 
     test 'returns an empty path when there is no anchor in the ref' do
       path = File.join(FILES_ROOT, 'openapi')
-      external = External.new(path:, ref: './schemas/author.yml')
+      external = External.new(basepath: path, path:, ref: './schemas/author.yml')
       assert_equal [], external.path
     end
 
     test 'returns a path when there is an anchor in the ref' do
       path = File.join(FILES_ROOT, 'openapi')
-      external = External.new(path:, ref: './schemas/author.yml#/properties/id')
+      external = External.new(basepath: path, path:, ref: './schemas/author.yml#/properties/id')
       assert_equal %w[properties id], external.path
     end
   end

--- a/test/reynard/schema/model_naming_test.rb
+++ b/test/reynard/schema/model_naming_test.rb
@@ -49,7 +49,7 @@ class Reynard
     class RegressionModelNamingTest < Reynard::Test
       EXPECTED = {
         'bare' => [],
-        'external' => %w[Author Bio Error],
+        'external' => %w[Author Bio Error Author Bio],
         'minimal' => %w[Spaceship SpaceshipCollection],
         'naming' => %w[
           Sector Subsector IndustryGroup Industry NationalIndustry Art NationalIndustry

--- a/test/reynard/specification_test.rb
+++ b/test/reynard/specification_test.rb
@@ -242,6 +242,15 @@ class Reynard
 
     test 'digs into an external file through a reference' do
       data = @specification.dig(
+        'paths', '/authors/me', 'get', 'responses', '200',
+        'content', 'application/json', 'schema',
+        'properties', 'id', 'type'
+      )
+      assert_equal 'integer', data
+    end
+
+    test 'digs into an external file through an explicit relative reference' do
+      data = @specification.dig(
         'paths', '/authors/{id}', 'get', 'responses', '200',
         'content', 'application/json', 'schema',
         'properties', 'id', 'type'


### PR DESCRIPTION
* Resolves relative $ref that does not start with `./`
* Fence relative loads based on the basename of the filename of the spec instead of the current file

Closes #8.