### PR TITLE
Support parameters with $ref with relative path into external file

### DIFF
--- a/lib/reynard/external.rb
+++ b/lib/reynard/external.rb
@@ -21,7 +21,10 @@ class Reynard
     def path
       return [] unless @anchor
 
-      @anchor.split('/')[1..]
+      # Remove explicit absolute (ie. /) and explicitly relative (ie. ./) instructions from the
+      # path expression because we're starting at the root of an external file. We currently don't
+      # support the // syntax.
+      @anchor.to_s.gsub(%r{\A\.?/}, '').split('/')
     end
 
     def data

--- a/lib/reynard/grouped_parameters.rb
+++ b/lib/reynard/grouped_parameters.rb
@@ -3,14 +3,21 @@
 class Reynard
   # Groups parameters based on the parameters specification.
   class GroupedParameters
-    def initialize(specification, params)
-      @specification = pivot(specification)
+    def initialize(specification:, node:, params:)
+      @specification = specification
+      @node = node
       @params = params
+    end
+
+    def constraints
+      return @constraints if defined?(@constraints)
+
+      @constraints = actualize(*@node, 'parameters') || actualize(*@node[..-2], 'parameters') || {}
     end
 
     def to_h
       @params.each_with_object({}) do |(name, value), grouped|
-        group_name = @specification.dig(name, 'in') || 'query'
+        group_name = constraints.dig(name, 'in') || 'query'
         grouped[group_name] ||= {}
         grouped[group_name].merge!({ name => value })
       end
@@ -18,12 +25,16 @@ class Reynard
 
     private
 
-    def pivot(specification)
-      return {} unless specification
+    def actualize(*node)
+      parameters = @specification.dig(*node)
+      return unless parameters
 
-      specification.each_with_object({}) do |attribute, pivot|
-        pivot[attribute['name']] = attribute
+      pivot = {}
+      parameters.each.with_index do |attributes, index|
+        attributes = @specification.dig(*node, index) if attributes.key?('$ref')
+        pivot[attributes['name']] = attributes
       end
+      pivot
     end
   end
 end

--- a/lib/reynard/specification.rb
+++ b/lib/reynard/specification.rb
@@ -47,13 +47,9 @@ class Reynard
       return {} unless params
 
       GroupedParameters.new(
-        [
-          # Parameters can be shared between methods on a path or be specific to an operation. The
-          # parameters on the operation level override those at the path level.
-          dig(*operation_node, 'parameters'),
-          dig(*operation_node[..-2], 'parameters')
-        ].compact.flatten,
-        params
+        specification: self,
+        node: operation_node,
+        params:
       ).to_h
     end
 

--- a/test/files/openapi/components/parameters.yml
+++ b/test/files/openapi/components/parameters.yml
@@ -1,0 +1,15 @@
+components:
+  parameters:
+    author_id:
+      name: id
+      in: path
+      description: The numeric ID of the author.
+      required: true
+      schema:
+        type: integer
+    version:
+      in: path
+      name: version
+      required: true
+      schema:
+        type: integer

--- a/test/files/openapi/external.yml
+++ b/test/files/openapi/external.yml
@@ -19,12 +19,7 @@ paths:
       tags:
         - authors
       parameters:
-        - name: id
-          in: path
-          description: The numeric ID of the author.
-          required: true
-          schema:
-            type: integer
+        - $ref: "components/parameters.yml#components/parameters/author_id"
       responses:
         "200":
           description: A author.

--- a/test/files/openapi/params.yml
+++ b/test/files/openapi/params.yml
@@ -10,6 +10,25 @@ tags:
   - name: parameters
     description: Complex parameters
 paths:
+  /spaces:
+    get:
+      summary: Get all color spaces
+      description: Get details about all color spaces.
+      operationId: getSpaces
+      tags:
+        - parameters
+      parameters:
+        - in: path
+          name: id
+        - in: query
+          name: format
+        - in: header
+          name: Accept
+        - in: cookie
+          name: authorization
+      responses:
+        "200":
+          description: A list of color spaces.
   /spaces/{name}:
     parameters:
       - in: path
@@ -33,7 +52,7 @@ paths:
       tags:
         - parameters
       responses:
-        '200':
+        "200":
           description: A color space.
     patch:
       summary: Update color space
@@ -52,5 +71,26 @@ paths:
       tags:
         - parameters
       responses:
-        '200':
+        "200":
           description: A color space.
+  /profiles/{name}/{version}:
+    get:
+      summary: Get color profile
+      description: Get details about a color profile.
+      operationId: getProfile
+      tags:
+        - parameters
+      parameters:
+        - $ref: "#/components/parameters/name"
+        - $ref: "components/parameters.yml#components/parameters/version"
+      responses:
+        "200":
+          description: A color profile.
+components:
+  parameters:
+    name:
+      in: path
+      name: name
+      required: true
+      schema:
+        type: string

--- a/test/reynard/external_test.rb
+++ b/test/reynard/external_test.rb
@@ -43,5 +43,17 @@ class Reynard
       external = External.new(basepath: path, path:, ref: './schemas/author.yml#/properties/id')
       assert_equal %w[properties id], external.path
     end
+
+    test 'returns a path when there is a relative anchor in the ref' do
+      path = File.join(FILES_ROOT, 'openapi')
+      external = External.new(basepath: path, path:, ref: './schemas/author.yml#properties/id')
+      assert_equal %w[properties id], external.path
+    end
+
+    test 'returns a path when there is an explicitly relative anchor in the ref' do
+      path = File.join(FILES_ROOT, 'openapi')
+      external = External.new(basepath: path, path:, ref: './schemas/author.yml#./properties/id')
+      assert_equal %w[properties id], external.path
+    end
   end
 end

--- a/test/reynard/grouped_parameters_test.rb
+++ b/test/reynard/grouped_parameters_test.rb
@@ -4,16 +4,28 @@ require_relative '../test_helper'
 
 class Reynard
   class GroupedParametersTest < Reynard::Test
+    def setup
+      @specification = Specification.new(filename: fixture_file('openapi/params.yml'))
+    end
+
     test 'includes parameters in query when specifications are not set' do
       assert_equal(
         { 'query' => { 'id' => 12 } },
-        GroupedParameters.new(nil, { 'id' => 12 }).to_h
+        GroupedParameters.new(
+          specification: @specification,
+          node: ['paths', '/spaces/{name}', 'get'],
+          params: { 'id' => 12 }
+        ).to_h
       )
     end
 
     test 'raises an exception when params are nil' do
       assert_raises(NoMethodError) do
-        GroupedParameters.new([], nil).to_h
+        GroupedParameters.new(
+          specification: @specification,
+          node: ['paths', '/spaces/{name}', 'get'],
+          params: nil
+        ).to_h
       end
     end
 
@@ -22,22 +34,36 @@ class Reynard
         {
           'path' => { 'id' => 12 },
           'query' => { 'format' => 'json', 'include' => 'author' },
-          'header' => { 'X-Customer-Code' => 'XX7234' },
+          'header' => { 'Accept' => 'text/plain' },
           'cookie' => { 'authorization' => 'a9a48294' }
         },
         GroupedParameters.new(
-          [
-            { 'name' => 'id', 'in' => 'path' },
-            { 'name' => 'format', 'in' => 'query' },
-            { 'name' => 'X-Customer-Code', 'in' => 'header' },
-            { 'name' => 'authorization', 'in' => 'cookie' }
-          ],
-          {
+          specification: @specification,
+          node: ['paths', '/spaces', 'get'],
+          params: {
             'id' => 12,
             'format' => 'json',
             'include' => 'author',
-            'X-Customer-Code' => 'XX7234',
+            'Accept' => 'text/plain',
             'authorization' => 'a9a48294'
+          }
+        ).to_h
+      )
+    end
+
+    test 'groups parameters by their place in the request when specified through $ref' do
+      assert_equal(
+        {
+          'path' => { 'name' => 'srgb', 'version' => 42 },
+          'query' => { 'page' => 12 }
+        },
+        GroupedParameters.new(
+          specification: @specification,
+          node: ['paths', '/profiles/{name}/{version}', 'get'],
+          params: {
+            'page' => 12,
+            'name' => 'srgb',
+            'version' => 42
           }
         ).to_h
       )

--- a/test/reynard/specification_test.rb
+++ b/test/reynard/specification_test.rb
@@ -214,6 +214,15 @@ class Reynard
         @specification.build_grouped_params(operation.node, params)
       )
     end
+
+    test 'applies a parameter specification when it was defined with a $ref' do
+      operation = @specification.operation('getProfile')
+      params = { 'name' => 'srgb', 'version' => 14 }
+      assert_equal(
+        { 'path' => { 'name' => 'srgb', 'version' => 14 } },
+        @specification.build_grouped_params(operation.node, params)
+      )
+    end
   end
 
   class BareSpecificationTest < Reynard::Test
@@ -265,6 +274,11 @@ class Reynard
         'properties', 'bio', 'properties', 'age', 'type'
       )
       assert_equal 'integer', data
+    end
+
+    test 'digs into an external file through a reference in an external file with an anchor' do
+      data = @specification.dig('paths', '/authors/{id}', 'get', 'parameters', 0, 'name')
+      assert_equal 'id', data
     end
 
     test 'digs into an external file with an anchor' do


### PR DESCRIPTION
* Adds support for a $ref in a list of parameter specifications.
* Adds support for a relative $ref into a different file.

```yaml
get:
  parameters:
    - $ref: 'components/parameters.yml#components/parameters/channel_id'
```

Closes #63.