### PR TITLE
Allow configuration of "permitted classes"

### DIFF
--- a/lib/reynard.rb
+++ b/lib/reynard.rb
@@ -60,6 +60,21 @@ class Reynard
     end
   end
 
+  def self.permitted_classes
+    @permitted_classes = parse_permitted_classes(ENV['REYNARD_PERMITTED_CLASSES']) || []
+  end
+
+  def self.parse_permitted_classes(env_value)
+    return nil unless env_value
+
+    env_value.split(',').map(&:strip).map do |class_name|
+      Object.const_get(class_name)
+    rescue NameError
+      warn "Warning: Could not find class #{class_name}"
+      nil
+    end.compact
+  end
+
   private
 
   def build_context

--- a/lib/reynard/specification.rb
+++ b/lib/reynard/specification.rb
@@ -105,7 +105,7 @@ class Reynard
 
     def read
       File.open(@filename, encoding: 'UTF-8') do |file|
-        YAML.safe_load(file, aliases: true)
+        YAML.safe_load(file, aliases: true, permitted_classes: Reynard.permitted_classes)
       end
     end
 


### PR DESCRIPTION
When dealing with more complex OpenAPI specifications, that make use of other data types than the standard types allowed by YAML (aka Psych), it is inevitable that you need to set the extra permitted classes using the `permitted_classes` argument.

An example of a class that you may want to permit is the `Date` class.

This PR provides a basic implementation of using a env variable to specify permitted classes.